### PR TITLE
Correct validation callback for selection of referencable types.

### DIFF
--- a/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesEntryTypes.php
+++ b/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesEntryTypes.php
@@ -112,8 +112,10 @@ class LocalgovDirectoriesEntryTypes extends SelectionPluginBase implements Conta
    * {@inheritdoc}
    */
   public function validateReferenceableEntities(array $ids) {
+    // Return only the $ids in $options, any others will be used in valdation
+    // to list as invalid.
     $options = $this->getReferenceableEntities();
-    return (0 === count(array_diff($ids, array_keys($options['node_type']))));
+    return array_intersect($ids, array_keys($options['node_type']));
   }
 
 }

--- a/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesEntryTypes.php
+++ b/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesEntryTypes.php
@@ -112,8 +112,9 @@ class LocalgovDirectoriesEntryTypes extends SelectionPluginBase implements Conta
    * {@inheritdoc}
    */
   public function validateReferenceableEntities(array $ids) {
-    // Return only the $ids in $options, any others will be used in valdation
+    // Return only the $ids in $options, any others will be used in validation
     // to list as invalid.
+    // @see Drupal\Core\Entity\Element\EntityAutocomplete::validateEntityAutocomplete()
     $options = $this->getReferenceableEntities();
     return array_intersect($ids, array_keys($options['node_type']));
   }


### PR DESCRIPTION
Rushed function didn't meet the interface. This has the node type assumption but I remember that was in-built. Now returns the correct selection of ids that are valid as an array.

Fixes #20 