### PR TITLE
Display Facet items as checkboxes

### DIFF
--- a/config/install/facets.facet.localgov_directories_facets.yml
+++ b/config/install/facets.facet.localgov_directories_facets.yml
@@ -15,7 +15,7 @@ show_only_one_result: false
 field_identifier: localgov_directory_facets_filter
 facet_source_id: 'search_api:views_embed__localgov_directory_channel__node_embed'
 widget:
-  type: links
+  type: checkbox
   config:
     show_numbers: false
     soft_limit: 0

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -29,6 +29,12 @@ function localgov_directories_theme() {
     'facets_item_list__links__localgov_directories_facets' => [
       'base hook' => 'facets_item_list',
     ],
+    // Facet Checkboxes are rendered through Javascript.  So the same markup as
+    // "link" Facets suffices.
+    'facets_item_list__checkbox__localgov_directories_facets' => [
+      'base hook' => 'facets_item_list',
+      'template'  => 'facets-item-list--links--localgov-directories-facets',
+    ],
   ];
 }
 

--- a/templates/facets-item-list--links--localgov-directories-facets.html.twig
+++ b/templates/facets-item-list--links--localgov-directories-facets.html.twig
@@ -38,6 +38,7 @@
     The js-facets-checkbox-links class is only meant for those ul/ol elements
     whose *direct* children are facet items and not titles or other ul/ol.
 
+    @see facets/templates/facets-item-list.html.twig
     @see Drupal.facets.makeCheckboxes()
   #}
   {% set top_list_type_attr = create_attribute(attributes.toArray()).removeClass('js-facets-checkbox-links') %}

--- a/templates/facets-item-list--links--localgov-directories-facets.html.twig
+++ b/templates/facets-item-list--links--localgov-directories-facets.html.twig
@@ -34,7 +34,14 @@
   {%- endif -%}
 
   {%- if items -%}
-  <{{ list_type }}{{ attributes }}>
+  {#
+    The js-facets-checkbox-links class is only meant for those ul/ol elements
+    whose *direct* children are facet items and not titles or other ul/ol.
+
+    @see Drupal.facets.makeCheckboxes()
+  #}
+  {% set top_list_type_attr = create_attribute(attributes.toArray()).removeClass('js-facets-checkbox-links') %}
+  <{{ list_type }}{{ top_list_type_attr }}>
   {%- for group in items -%}
     <li{{ group.attributes }}>{{ group.title }}</li>
     <{{ list_type }}{{ attributes.addClass('facet-filter-checkboxes') }}>


### PR DESCRIPTION
The Facet module is not expecting hierarchical list items (i.e. lists inside lists) as Facet markup when rendering **checkboxes** for Facets.  Slight adjustments to our Facet markup convinces it to carry on.

Closes #39 