### PR TITLE
Facet group heading: Clearly identify group heading.

### DIFF
--- a/templates/facets-item-list--links--localgov-directories-facets.html.twig
+++ b/templates/facets-item-list--links--localgov-directories-facets.html.twig
@@ -44,7 +44,7 @@
   {% set top_list_type_attr = create_attribute(attributes.toArray()).removeClass('js-facets-checkbox-links') %}
   <{{ list_type }}{{ top_list_type_attr }}>
   {%- for group in items -%}
-    <li{{ group.attributes }}>{{ group.title }}</li>
+    <li{{ group.attributes }}><h4 class="facet-group__title">{{ group.title }}</h4></li>
     <{{ list_type }}{{ attributes.addClass('facet-filter-checkboxes') }}>
     {%- for item in group.items -%}
       <li{{ item.attributes }}>{{ item.value }}</li>


### PR DESCRIPTION
Facet header items should be wrapped in a header tag.  This change was going into the
localgov_theme in the form of an *overridden* Twig template.  But it looks so
appropriate that we thought it better to include it in the source template.

Issue: https://github.com/localgovdrupal/localgov_theme/issues/85

FAO @finnlewis @cjstevens78 