### PR TITLE
Facet weight

### DIFF
--- a/config/conditional/facets.facet.localgov_directories_facets.yml
+++ b/config/conditional/facets.facet.localgov_directories_facets.yml
@@ -33,12 +33,6 @@ hard_limit: 0
 exclude: false
 only_visible_when_facet_source_is_visible: false
 processor_configs:
-  display_value_widget_order:
-    processor_id: display_value_widget_order
-    weights:
-      sort: 40
-    settings:
-      sort: ASC
   translate_entity:
     processor_id: translate_entity
     weights:
@@ -50,6 +44,12 @@ processor_configs:
       pre_query: 50
       build: 15
     settings: {  }
+  weight_property_order:
+    processor_id: weight_property_order
+    weights:
+      sort: 50
+    settings:
+      sort: ASC
 empty_behavior:
   behavior: none
 show_title: false

--- a/config/conditional/facets.facet.localgov_directories_facets.yml
+++ b/config/conditional/facets.facet.localgov_directories_facets.yml
@@ -33,6 +33,12 @@ hard_limit: 0
 exclude: false
 only_visible_when_facet_source_is_visible: false
 processor_configs:
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
   translate_entity:
     processor_id: translate_entity
     weights:
@@ -47,7 +53,7 @@ processor_configs:
   weight_property_order:
     processor_id: weight_property_order
     weights:
-      sort: 50
+      sort: -5
     settings:
       sort: ASC
 empty_behavior:

--- a/config/schema/localgov_directories.entity_type.schema.yml
+++ b/config/schema/localgov_directories.entity_type.schema.yml
@@ -8,5 +8,8 @@ localgov_directories.localgov_directories_facets_type.*:
     label:
       type: label
       label: 'Label'
+    weight:
+      type: integer
+      label: 'Weight'
     uuid:
       type: string

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -28,7 +28,12 @@ function localgov_directories_update_8001() {
   $field_storage_def_for_weight = BaseFieldDefinition::create('integer')
     ->setLabel(t('Weight'))
     ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
-    ->setDefaultValue(0);
+    ->setDefaultValue(0)
+    ->setDisplayOptions('form', [
+      'type' => 'number',
+      'weight' => 50,
+   ])
+   ->setDisplayConfigurable('form', TRUE);
 
   Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('weight', 'localgov_directories_facets', 'localgov_directories', $field_storage_def_for_weight);

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the LocalGov Directories module.
  */
 
+use Drupal\Core\Field\BaseFieldDefinition;
+
 /**
  * Implements hook_install().
  */
@@ -13,4 +15,21 @@ function localgov_directories_install() {
   if ($services) {
     localgov_directories_optional_fields_settings($services);
   }
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Adds the "weight" field to Facet related entities.
+ */
+function localgov_directories_update_8001() {
+
+  // @see Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets::baseFieldDefinitions()
+  $field_storage_def_for_weight = BaseFieldDefinition::create('integer')
+    ->setLabel(t('Weight'))
+    ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
+    ->setDefaultValue(0);
+
+  Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('weight', 'localgov_directories_facets', 'localgov_directories', $field_storage_def_for_weight);
 }

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -24,6 +24,7 @@ function localgov_directories_install() {
  */
 function localgov_directories_update_8001() {
 
+  // First, localgov_directories_facets content entity.
   // @see Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets::baseFieldDefinitions()
   $field_storage_def_for_weight = BaseFieldDefinition::create('integer')
     ->setLabel(t('Weight'))
@@ -32,9 +33,37 @@ function localgov_directories_update_8001() {
     ->setDisplayOptions('form', [
       'type' => 'number',
       'weight' => 50,
-   ])
-   ->setDisplayConfigurable('form', TRUE);
+    ])
+    ->setDisplayConfigurable('form', TRUE);
 
   Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('weight', 'localgov_directories_facets', 'localgov_directories', $field_storage_def_for_weight);
+
+  // Next, localgov_directories_facets_type config entities.
+  $config_factory = Drupal::service('config.factory');
+  $facet_type_config_entities = $config_factory->listAll('localgov_directories.localgov_directories_facets_type.');
+  array_walk($facet_type_config_entities, function ($facet_type_entity_id) use ($config_factory) {
+    $facet_type_config = $config_factory->getEditable($facet_type_entity_id);
+    $has_facet = $facet_type_config->get('weight') ?? FALSE;
+    if (!$has_facet) {
+      $facet_type_config->set('weight', 0);
+      $facet_type_config->save(TRUE);
+    }
+  });
+
+  // Finally, the Facet configuration itself.
+  $dir_facet_config = $config_factory->getEditable('facets.facet.localgov_directories_facets');
+  $has_dir_facet_config = $dir_facet_config->get('id') ?? FALSE;
+  if (!$has_dir_facet_config) {
+    return;
+  }
+  $facet_processor_configs = $dir_facet_config->get('processor_configs');
+  unset($facet_processor_configs['display_value_widget_order']);
+  $facet_processor_configs['weight_property_order'] = [
+    'processor_id' => 'weight_property_order',
+    'weights' => ['sort' => 50],
+    'settings' => ['sort' => 'ASC'],
+  ];
+  $dir_facet_config->set('processor_configs', $facet_processor_configs);
+  $dir_facet_config->save(TRUE);
 }

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -30,6 +30,7 @@ function localgov_directories_update_8001() {
     ->setLabel(t('Weight'))
     ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
     ->setDefaultValue(0)
+    ->setInitialValue(0)
     ->setDisplayOptions('form', [
       'type' => 'number',
       'weight' => 50,

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -44,8 +44,8 @@ function localgov_directories_update_8001() {
   $facet_type_config_entities = $config_factory->listAll('localgov_directories.localgov_directories_facets_type.');
   array_walk($facet_type_config_entities, function ($facet_type_entity_id) use ($config_factory) {
     $facet_type_config = $config_factory->getEditable($facet_type_entity_id);
-    $has_facet = $facet_type_config->get('weight') ?? FALSE;
-    if (!$has_facet) {
+    $has_facet_weight = $facet_type_config->get('weight') ?? FALSE;
+    if (!$has_facet_weight) {
       $facet_type_config->set('weight', 0);
       $facet_type_config->save(TRUE);
     }

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -62,7 +62,7 @@ function localgov_directories_update_8001() {
   unset($facet_processor_configs['display_value_widget_order']);
   $facet_processor_configs['weight_property_order'] = [
     'processor_id' => 'weight_property_order',
-    'weights' => ['sort' => 50],
+    'weights' => ['sort' => -5],
     'settings' => ['sort' => 'ASC'],
   ];
   $dir_facet_config->set('processor_configs', $facet_processor_configs);

--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -276,17 +276,18 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface {
   /**
    * Facet bundle comparison callback for sorting.
    *
-   * Bundles are compared by their weight.
+   * Bundles are compared by their weights.  When weights are equal, labels take
+   * over.
    *
    * @param array $bundle1
-   *   Necessary key: weight.
+   *   Necessary keys: weight, title.
    * @param array $bundle2
    *   Same as $bundle1.
    */
   public static function compareFacetBundlesByWeight(array $bundle1, array $bundle2): int {
 
     if ($bundle1['weight'] === $bundle2['weight']) {
-      return 0;
+      return strnatcasecmp($bundle1['title'], $bundle2['title']);
     }
 
     return $bundle1['weight'] < $bundle2['weight'] ? -1 : 1;

--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -226,7 +226,10 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface {
         $form['#attributes']['class'][] = $delta ? 'localgov-search-channel-secondary' : 'localgov-search-channel-primary';
         $channel_label = $this->entityRepository->getTranslationFromContext($node)->label();
         $form['#id'] .= '--' . $node->id();
-        $form["#info"]["filter-search_api_fulltext"]["label"] = $this->t('Search <span class="localgov-search-channel" id="@id--channel">@channel</span>', ['@id' => $form['#id'], '@channel' => $channel_label]);
+        $form["#info"]["filter-search_api_fulltext"]["label"] = $this->t('Search <span class="localgov-search-channel" id="@id--channel">@channel</span>', [
+          '@id' => $form['#id'],
+          '@channel' => $channel_label,
+        ]);
         // Can we do this with the form builder?
         // Do we need to deal with date-drupal-selector?
         // Questions for search_api_autocomplete?
@@ -242,6 +245,8 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface {
 
   /**
    * Prepares variables for our bundle grouped facets item list template.
+   *
+   * Facet bundles are sorted based on their weight.
    *
    * @see templates/facets-item-list--links--localgov-directories-facets.tpl.php
    * @see localgov_directories_preprocess_facets_item_list()
@@ -262,8 +267,29 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface {
       $entity = $type_storage->load($bundle);
       assert($entity instanceof LocalgovDirectoriesFacetsType);
       $group_items[$bundle]['title'] = Html::escape($this->entityRepository->getTranslationFromContext($entity)->label());
+      $group_items[$bundle]['weight'] = $entity->get('weight');
     }
+    uasort($group_items, 'static::compareFacetBundlesByWeight');
     $variables['items'] = $group_items;
+  }
+
+  /**
+   * Facet bundle comparison callback for sorting.
+   *
+   * Bundles are compared by their weight.
+   *
+   * @param array $bundle1
+   *   Necessary key: weight.
+   * @param array $bundle2
+   *   Same as $bundle1.
+   */
+  public static function compareFacetBundlesByWeight(array $bundle1, array $bundle2): int {
+
+    if ($bundle1['weight'] === $bundle2['weight']) {
+      return 0;
+    }
+
+    return $bundle1['weight'] < $bundle2['weight'] ? -1 : 1;
   }
 
 }

--- a/src/Entity/LocalgovDirectoriesFacets.php
+++ b/src/Entity/LocalgovDirectoriesFacets.php
@@ -218,6 +218,7 @@ class LocalgovDirectoriesFacets extends ContentEntityBase implements LocalgovDir
       ->setLabel(t('Weight'))
       ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
       ->setDefaultValue(0)
+      ->setInitialValue(0)
       ->setDisplayOptions('form', [
         'type' => 'number',
         'weight' => 50,

--- a/src/Entity/LocalgovDirectoriesFacets.php
+++ b/src/Entity/LocalgovDirectoriesFacets.php
@@ -41,7 +41,8 @@ use Drupal\user\UserInterface;
  *     "langcode" = "langcode",
  *     "bundle" = "bundle",
  *     "label" = "title",
- *     "uuid" = "uuid"
+ *     "uuid" = "uuid",
+ *     "weight" = "weight"
  *   },
  *   links = {
  *     "add-form" = "/admin/content/directories/facets/add/{localgov_directories_facets_type}",
@@ -216,7 +217,12 @@ class LocalgovDirectoriesFacets extends ContentEntityBase implements LocalgovDir
     $fields['weight'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Weight'))
       ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
-      ->setDefaultValue(0);
+      ->setDefaultValue(0)
+      ->setDisplayOptions('form', [
+        'type' => 'number',
+        'weight' => 50,
+      ])
+      ->setDisplayConfigurable('form', TRUE);
 
     return $fields;
   }

--- a/src/Entity/LocalgovDirectoriesFacets.php
+++ b/src/Entity/LocalgovDirectoriesFacets.php
@@ -16,7 +16,7 @@ use Drupal\user\UserInterface;
  * @ContentEntityType(
  *   id = "localgov_directories_facets",
  *   label = @Translation("Directory Facets"),
- *   label_collection = @Translation("Directory Facetses"),
+ *   label_collection = @Translation("Directory Facets"),
  *   bundle_label = @Translation("Directory Facets type"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
@@ -133,6 +133,21 @@ class LocalgovDirectoriesFacets extends ContentEntityBase implements LocalgovDir
   /**
    * {@inheritdoc}
    */
+  public function getWeight() {
+    return $this->get('weight')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setWeight($weight) {
+    $this->set('weight', $weight);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
 
     $fields = parent::baseFieldDefinitions($entity_type);
@@ -197,6 +212,11 @@ class LocalgovDirectoriesFacets extends ContentEntityBase implements LocalgovDir
       ->setLabel(t('Changed'))
       ->setTranslatable(TRUE)
       ->setDescription(t('The time that the directory facets was last edited.'));
+
+    $fields['weight'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Weight'))
+      ->setDescription(t('The weight of this Directory facet in relation to other facets.'))
+      ->setDefaultValue(0);
 
     return $fields;
   }

--- a/src/Entity/LocalgovDirectoriesFacetsType.php
+++ b/src/Entity/LocalgovDirectoriesFacetsType.php
@@ -27,7 +27,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *   entity_keys = {
  *     "id" = "id",
  *     "label" = "label",
- *     "uuid" = "uuid"
+ *     "uuid" = "uuid",
+ *     "weight" = "weight",
  *   },
  *   links = {
  *     "add-form" = "/admin/structure/localgov_directories_facets_types/add",
@@ -39,6 +40,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "id",
  *     "label",
  *     "uuid",
+ *     "weight",
  *   }
  * )
  */
@@ -57,5 +59,12 @@ class LocalgovDirectoriesFacetsType extends ConfigEntityBundleBase {
    * @var string
    */
   protected $label;
+
+  /**
+   * Facet type weight.
+   *
+   * @var integer
+   */
+  protected $weight = 0;
 
 }

--- a/src/Entity/LocalgovDirectoriesFacetsType.php
+++ b/src/Entity/LocalgovDirectoriesFacetsType.php
@@ -63,7 +63,7 @@ class LocalgovDirectoriesFacetsType extends ConfigEntityBundleBase {
   /**
    * Facet type weight.
    *
-   * @var integer
+   * @var int
    */
   protected $weight = 0;
 

--- a/src/Form/LocalgovDirectoriesFacetsForm.php
+++ b/src/Form/LocalgovDirectoriesFacetsForm.php
@@ -12,6 +12,27 @@ class LocalgovDirectoriesFacetsForm extends ContentEntityForm {
 
   /**
    * {@inheritdoc}
+   *
+   * Adds the "weight" field to the mix.
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+
+    $facet_item = $this->entity;
+
+    $form['weight'] = [
+      '#type'          => 'weight',
+      '#title'         => $this->t('Weight'),
+      '#description'   => $this->t('Facets are displayed in ascending order by weight.'),
+      '#default_value' => $facet_item->getWeight() ?? 0,
+      '#delta'         => 50,
+      '#weight'        => 100,
+    ];
+
+    return parent::form($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
 

--- a/src/Form/LocalgovDirectoriesFacetsForm.php
+++ b/src/Form/LocalgovDirectoriesFacetsForm.php
@@ -12,27 +12,6 @@ class LocalgovDirectoriesFacetsForm extends ContentEntityForm {
 
   /**
    * {@inheritdoc}
-   *
-   * Adds the "weight" field to the mix.
-   */
-  public function form(array $form, FormStateInterface $form_state) {
-
-    $facet_item = $this->entity;
-
-    $form['weight'] = [
-      '#type'          => 'weight',
-      '#title'         => $this->t('Weight'),
-      '#description'   => $this->t('Facets are displayed in ascending order by weight.'),
-      '#default_value' => $facet_item->getWeight() ?? 0,
-      '#delta'         => 50,
-      '#weight'        => 100,
-    ];
-
-    return parent::form($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
 

--- a/src/Form/LocalgovDirectoriesFacetsTypeForm.php
+++ b/src/Form/LocalgovDirectoriesFacetsTypeForm.php
@@ -48,6 +48,15 @@ class LocalgovDirectoriesFacetsTypeForm extends BundleEntityFormBase {
       '#description' => $this->t('A unique machine-readable name for this directory facets type. It must only contain lowercase letters, numbers, and underscores.'),
     ];
 
+    $form['weight'] = [
+      '#type'          => 'weight',
+      '#title'         => $this->t('Weight'),
+      '#description'   => $this->t('Facet types are displayed in ascending order by weight.'),
+      '#default_value' => $entity_type->get('weight'),
+      '#delta'         => 50,
+      '#weight'        => 100,
+    ];
+
     return $this->protectBundleIdElement($form);
   }
 
@@ -69,6 +78,7 @@ class LocalgovDirectoriesFacetsTypeForm extends BundleEntityFormBase {
 
     $entity_type->set('id', trim($entity_type->id()));
     $entity_type->set('label', trim($entity_type->label()));
+    $entity_type->set('weight', $entity_type->get('weight'));
 
     $status = $entity_type->save();
 

--- a/src/LocalgovDirectoriesFacetsListBuilder.php
+++ b/src/LocalgovDirectoriesFacetsListBuilder.php
@@ -60,6 +60,23 @@ class LocalgovDirectoriesFacetsListBuilder extends EntityListBuilder {
   }
 
   /**
+   * Loads entity IDs using a pager sorted by the entity weight.
+   *
+   * @return array
+   *   An array of entity IDs.
+   */
+  protected function getEntityIds() {
+    $query = $this->getStorage()->getQuery()
+      ->sort($this->entityType->getKey('weight'));
+
+    // Only add the pager if a limit is specified.
+    if ($this->limit) {
+      $query->pager($this->limit);
+    }
+    return $query->execute();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function render() {
@@ -89,7 +106,7 @@ class LocalgovDirectoriesFacetsListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
-    /* @var $entity \Drupal\localgov_directories\LocalgovDirectoriesFacetsInterface */
+    /** @var \Drupal\localgov_directories\LocalgovDirectoriesFacetsInterface $entity */
     $row['id'] = $entity->id();
     $row['bundle'] = $entity->bundle();
     $row['title'] = $entity->toLink(NULL, 'edit-form');

--- a/src/LocalgovDirectoriesFacetsListBuilder.php
+++ b/src/LocalgovDirectoriesFacetsListBuilder.php
@@ -12,6 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a list controller for the directory facets entity type.
+ *
+ * Directory facets are order by their Facet type, weight, and label.
  */
 class LocalgovDirectoriesFacetsListBuilder extends EntityListBuilder {
 
@@ -60,14 +62,19 @@ class LocalgovDirectoriesFacetsListBuilder extends EntityListBuilder {
   }
 
   /**
-   * Loads entity IDs using a pager sorted by the entity weight.
+   * Loads entity IDs using a pager sorted by various entity properties.
+   *
+   * While sorting, entity properties are used in this order: bundle, weight,
+   * and label.
    *
    * @return array
    *   An array of entity IDs.
    */
   protected function getEntityIds() {
     $query = $this->getStorage()->getQuery()
-      ->sort($this->entityType->getKey('weight'));
+      ->sort($this->entityType->getKey('bundle'))
+      ->sort($this->entityType->getKey('weight'))
+      ->sort($this->entityType->getKey('label'));
 
     // Only add the pager if a limit is specified.
     if ($this->limit) {

--- a/src/LocalgovDirectoriesFacetsTypeListBuilder.php
+++ b/src/LocalgovDirectoriesFacetsTypeListBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\localgov_directories;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Config\Entity\DraggableListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 
@@ -11,7 +12,7 @@ use Drupal\Core\Url;
  *
  * @see \Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType
  */
-class LocalgovDirectoriesFacetsTypeListBuilder extends ConfigEntityListBuilder {
+class LocalgovDirectoriesFacetsTypeListBuilder extends DraggableListBuilder {
 
   /**
    * {@inheritdoc}
@@ -26,10 +27,8 @@ class LocalgovDirectoriesFacetsTypeListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
-    $row['title'] = [
-      'data' => $entity->label(),
-      'class' => ['menu-label'],
-    ];
+
+    $row['label'] = $entity->label();
 
     return $row + parent::buildRow($entity);
   }
@@ -46,6 +45,14 @@ class LocalgovDirectoriesFacetsTypeListBuilder extends ConfigEntityListBuilder {
     );
 
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+
+    return 'localgov_directories_facet_type_list_form';
   }
 
 }

--- a/src/LocalgovDirectoriesFacetsTypeListBuilder.php
+++ b/src/LocalgovDirectoriesFacetsTypeListBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_directories;
 
-use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Config\Entity\DraggableListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;

--- a/src/Plugin/facets/processor/WeightOrderProcessor.php
+++ b/src/Plugin/facets/processor/WeightOrderProcessor.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\facets\Processor\SortProcessorPluginBase;
 use Drupal\facets\Result\ResultInterface;
+use Drupal\facets\Result\Result;
 use Drupal\localgov_directories\Constants as Directory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -31,7 +32,7 @@ class WeightOrderProcessor extends SortProcessorPluginBase implements ContainerF
    *
    * Compare *Facet items* by the value of their *weight* property.
    */
-  public function sortResults(ResultInterface $a, ResultInterface $b) {
+  public function sortResults(Result $a, Result $b) {
 
     $this->loadFacetWeightsOnce($a, $b);
 

--- a/src/Plugin/facets/processor/WeightOrderProcessor.php
+++ b/src/Plugin/facets/processor/WeightOrderProcessor.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\localgov_directories\Plugin\facets\processor;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\facets\Processor\SortProcessorPluginBase;
+use Drupal\facets\Result\ResultInterface;
+use Drupal\localgov_directories\Constants as Directory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Sort Facet items by their weight property.
+ *
+ * @FacetsProcessor(
+ *   id = "weight_property_order",
+ *   label = @Translation("Sort by weight."),
+ *   description = @Translation("Sorts the widget results by their weight."),
+ *   default_enabled = TRUE,
+ *   stages = {
+ *     "sort" = 50
+ *   }
+ * )
+ */
+class WeightOrderProcessor extends SortProcessorPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Compare *Facet items* by the value of their *weight* property.
+   */
+  public function sortResults(ResultInterface $a, ResultInterface $b) {
+
+    $this->loadFacetWeightsOnce($a, $b);
+
+    if ($a->facetWeight === $b->facetWeight) {
+      return 0;
+    }
+
+    return ($a->facetWeight < $b->facetWeight) ? -1 : 1;
+  }
+
+  /**
+   * Loads the weight value into the facetWeight property of each Result item.
+   *
+   * Here we strive to load each Facet item only once for performance reasons.
+   * When a Facet item is sent for comparison for the first time, we load its
+   * weight and retain it as the value of its *facetWeight* property.
+   * Subsequent comparisons reuse this weight value instead of reloading this
+   * Facet item.
+   */
+  protected function loadFacetWeightsOnce(ResultInterface $a, ResultInterface $b): void {
+
+    if (!isset($a->facetWeight)) {
+      $a_facet_id     = $a->getRawValue();
+      $a_facet_entity = $this->dirFacetStorage->load($a_facet_id);
+      $a->facetWeight = $a_facet_entity->getWeight() ?? 0;
+    }
+
+    if (!isset($b->facetWeight)) {
+      $b_facet_id     = $b->getRawValue();
+      $b_facet_entity = $this->dirFacetStorage->load($b_facet_id);
+      $b->facetWeight = $b_facet_entity->getWeight() ?? 0;
+    }
+  }
+
+  /**
+   * Constructs a new object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->dirFacetStorage = $entity_type_manager->getStorage(Directory::FACET_CONFIG_ENTITY_ID);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * LocalGov Directory Facets entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $dirFacetStorage;
+
+}

--- a/src/Plugin/facets/processor/WeightOrderProcessor.php
+++ b/src/Plugin/facets/processor/WeightOrderProcessor.php
@@ -16,8 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @FacetsProcessor(
  *   id = "weight_property_order",
- *   label = @Translation("Sort by weight."),
- *   description = @Translation("Sorts the widget results by their weight."),
+ *   label = @Translation("Sort by weight"),
+ *   description = @Translation("Sorts the widget results by their weight.  Only applies to Facet items with a *weight* property."),
  *   default_enabled = TRUE,
  *   stages = {
  *     "sort" = 50
@@ -56,13 +56,13 @@ class WeightOrderProcessor extends SortProcessorPluginBase implements ContainerF
     if (!isset($a->facetWeight)) {
       $a_facet_id     = $a->getRawValue();
       $a_facet_entity = $this->dirFacetStorage->load($a_facet_id);
-      $a->facetWeight = $a_facet_entity->getWeight() ?? 0;
+      $a->facetWeight = $a_facet_entity->get('weight')->value ?? 0;
     }
 
     if (!isset($b->facetWeight)) {
       $b_facet_id     = $b->getRawValue();
       $b_facet_entity = $this->dirFacetStorage->load($b_facet_id);
-      $b->facetWeight = $b_facet_entity->getWeight() ?? 0;
+      $b->facetWeight = $b_facet_entity->get('weight')->value ?? 0;
     }
   }
 

--- a/tests/src/Unit/FacetPreprocessTest.php
+++ b/tests/src/Unit/FacetPreprocessTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\localgov_directories\Unit;
+
+use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
+use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for the DirectoryExtraFieldDisplay class.
+ */
+class FacetPreprocessTest extends UnitTestCase {
+
+  /**
+   * Tests for DirectoryExtraFieldDisplay::preprocessFacetList().
+   *
+   * Ensure that the *Facet types* are sorted according to their weights.
+   *
+   * ## Test data
+   * Facet item | Facet type | Facet type weight
+   * -----------+------------+------------------
+   * zero       | foo        | 30
+   * one        | bar        | 10
+   * two        | baz        | 20
+   * three      | qux        | 0
+   *
+   * The expected output order of the Facet types is: qux, bar, baz, foo.
+   */
+  public function testFacetTypeSorting() {
+
+    $test_obj = new DirectoryExtraFieldDisplay($this->mockEntityTypeManager, $this->mockEntityRepository, $this->mockEntityFieldManager, $this->mockBlockPluginManager, $this->mockFormBuilder);
+
+    $facet_tpl_variables = [
+      'items' => [
+        ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'zero']]],
+        ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'one']]],
+        ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'two']]],
+        ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'three']]],
+      ],
+    ];
+    $test_obj->preprocessFacetList($facet_tpl_variables);
+
+    $sorted_facet_types = array_keys($facet_tpl_variables['items']);
+    $expected_sorted_facet_types = ['qux', 'bar', 'baz', 'foo'];
+    $this->assertArrayEquals($expected_sorted_facet_types, $sorted_facet_types);
+  }
+
+  /**
+   * Create the mock dependencies.
+   *
+   * Initialize everything needed to create a DirectoryExtraFieldDisplay object.
+   *
+   * @see DirectoryExtraFieldDisplay::__construct()
+   */
+  public function setup() {
+
+    // Facet items.
+    $facet_zero = $this->createMock(LocalgovDirectoriesFacets::class);
+    $facet_zero->expects($this->any())->method('bundle')->willReturn('foo');
+    $facet_one = $this->createMock(LocalgovDirectoriesFacets::class);
+    $facet_one->expects($this->any())->method('bundle')->willReturn('bar');
+    $facet_two = $this->createMock(LocalgovDirectoriesFacets::class);
+    $facet_two->expects($this->any())->method('bundle')->willReturn('baz');
+    $facet_three = $this->createMock(LocalgovDirectoriesFacets::class);
+    $facet_three->expects($this->any())->method('bundle')->willReturn('qux');
+
+    $mock_facet_storage = $this->createMock(EntityStorageInterface::class);
+    $mock_facet_storage->expects($this->any())
+      ->method('load')
+      ->will($this->returnValueMap([
+        ['zero', $facet_zero],
+        ['one', $facet_one],
+        ['two', $facet_two],
+        ['three', $facet_three],
+      ]));
+
+    // Facet types.
+    $facet_type_foo = $this->createMock(LocalgovDirectoriesFacetsType::class);
+    $facet_type_foo->expects($this->any())->method('get')->willReturn(30);
+    $facet_type_foo->expects($this->any())->method('label')->willReturn('foo');
+    $facet_type_bar = $this->createMock(LocalgovDirectoriesFacetsType::class);
+    $facet_type_bar->expects($this->any())->method('get')->willReturn(10);
+    $facet_type_bar->expects($this->any())->method('label')->willReturn('bar');
+    $facet_type_baz = $this->createMock(LocalgovDirectoriesFacetsType::class);
+    $facet_type_baz->expects($this->any())->method('get')->willReturn(20);
+    $facet_type_baz->expects($this->any())->method('label')->willReturn('baz');
+    $facet_type_qux = $this->createMock(LocalgovDirectoriesFacetsType::class);
+    $facet_type_qux->expects($this->any())->method('get')->willReturn(0);
+    $facet_type_qux->expects($this->any())->method('label')->willReturn('qux');
+
+    $mock_facet_type_storage = $this->createMock(EntityStorageInterface::class);
+    $mock_facet_type_storage->expects($this->any())
+      ->method('load')
+      ->will($this->returnValueMap([
+        ['foo', $facet_type_foo],
+        ['bar', $facet_type_bar],
+        ['baz', $facet_type_baz],
+        ['qux', $facet_type_qux],
+      ]));
+
+    // Finally, the dependencies.
+    $this->mockEntityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->mockEntityTypeManager->expects($this->any())
+      ->method('getStorage')
+      ->will($this->returnValueMap([
+        ['localgov_directories_facets', $mock_facet_storage],
+        ['localgov_directories_facets_type', $mock_facet_type_storage],
+      ]));
+
+    $this->mockEntityRepository = $this->createMock(EntityRepositoryInterface::class);
+    $this->mockEntityRepository->expects($this->any())
+      ->method('getTranslationFromContext')
+      ->will($this->returnCallback(function ($arg) {
+        return $arg;
+      }));
+
+    $this->mockEntityFieldManager = $this->createMock(EntityFieldManagerInterface::class);
+    $this->mockBlockPluginManager = $this->createMock(BlockManagerInterface::class);
+    $this->mockFormBuilder        = $this->createMock(FormBuilderInterface::class);
+  }
+
+  /**
+   * Mock entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $mockEntityTypeManager;
+
+  /**
+   * Mock entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $mockEntityRepository;
+
+  /**
+   * Mock entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $mockEntityFieldManager;
+
+  /**
+   * Mock block plugin manager.
+   *
+   * @var \Drupal\Core\Block\BlockManagerInterface
+   */
+  protected $mockBlockPluginManager;
+
+  /**
+   * Mock form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $mockFormBuilder;
+
+}

--- a/tests/src/Unit/FacetPreprocessTest.php
+++ b/tests/src/Unit/FacetPreprocessTest.php
@@ -25,7 +25,8 @@ class FacetPreprocessTest extends UnitTestCase {
   /**
    * Tests for DirectoryExtraFieldDisplay::preprocessFacetList().
    *
-   * Ensure that the *Facet types* are sorted according to their weights.
+   * Ensures that the *Facet types* are sorted according to their weights and
+   * labels.
    *
    * ## Test data
    * Facet item | Facet type | Facet type weight
@@ -34,8 +35,9 @@ class FacetPreprocessTest extends UnitTestCase {
    * one        | bar        | 10
    * two        | baz        | 20
    * three      | qux        | 0
+   * four       | jar        | 0
    *
-   * The expected output order of the Facet types is: qux, bar, baz, foo.
+   * The expected output order of the Facet types is: jar, qux, bar, baz, foo.
    */
   public function testFacetTypeSorting() {
 
@@ -47,12 +49,13 @@ class FacetPreprocessTest extends UnitTestCase {
         ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'one']]],
         ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'two']]],
         ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'three']]],
+        ['value' => ['#attributes' => ['data-drupal-facet-item-value' => 'four']]],
       ],
     ];
     $test_obj->preprocessFacetList($facet_tpl_variables);
 
     $sorted_facet_types = array_keys($facet_tpl_variables['items']);
-    $expected_sorted_facet_types = ['qux', 'bar', 'baz', 'foo'];
+    $expected_sorted_facet_types = ['jar', 'qux', 'bar', 'baz', 'foo'];
     $this->assertArrayEquals($expected_sorted_facet_types, $sorted_facet_types);
   }
 
@@ -74,6 +77,8 @@ class FacetPreprocessTest extends UnitTestCase {
     $facet_two->expects($this->any())->method('bundle')->willReturn('baz');
     $facet_three = $this->createMock(LocalgovDirectoriesFacets::class);
     $facet_three->expects($this->any())->method('bundle')->willReturn('qux');
+    $facet_four = $this->createMock(LocalgovDirectoriesFacets::class);
+    $facet_four->expects($this->any())->method('bundle')->willReturn('jar');
 
     $mock_facet_storage = $this->createMock(EntityStorageInterface::class);
     $mock_facet_storage->expects($this->any())
@@ -83,6 +88,7 @@ class FacetPreprocessTest extends UnitTestCase {
         ['one', $facet_one],
         ['two', $facet_two],
         ['three', $facet_three],
+        ['four', $facet_four],
       ]));
 
     // Facet types.
@@ -98,6 +104,9 @@ class FacetPreprocessTest extends UnitTestCase {
     $facet_type_qux = $this->createMock(LocalgovDirectoriesFacetsType::class);
     $facet_type_qux->expects($this->any())->method('get')->willReturn(0);
     $facet_type_qux->expects($this->any())->method('label')->willReturn('qux');
+    $facet_type_jar = $this->createMock(LocalgovDirectoriesFacetsType::class);
+    $facet_type_jar->expects($this->any())->method('get')->willReturn(0);
+    $facet_type_jar->expects($this->any())->method('label')->willReturn('jar');
 
     $mock_facet_type_storage = $this->createMock(EntityStorageInterface::class);
     $mock_facet_type_storage->expects($this->any())
@@ -107,6 +116,7 @@ class FacetPreprocessTest extends UnitTestCase {
         ['bar', $facet_type_bar],
         ['baz', $facet_type_baz],
         ['qux', $facet_type_qux],
+        ['jar', $facet_type_jar],
       ]));
 
     // Finally, the dependencies.


### PR DESCRIPTION
- Added a "weight" field to both the localgov_directories_facets content entity and localgov_directories_facets_type config entity.
- A facet sort plugin that respects the weight property of localgov_directoires_facets entities.
- An update hook to "activate" the above.
- Convinced our custom [facet template preprocessor](https://github.com/localgovdrupal/localgov_directories/blob/f68e7d5e0952534ff14317cf6a12690aba2b29cc/src/DirectoryExtraFieldDisplay.php#L249) to respect the weight property of the localgov_directories_facets_type entities.

### Improvement ideas
- ~A Functional test to verify that the Facets are indeed rendered based on their weight.  I will raise a separate ticket for this.~  This already [exists](https://github.com/localgovdrupal/localgov_directories/issues/18) thanks to @ekes 

Resolves #35 