### PR TITLE
Fix typo for collection name.

### DIFF
--- a/src/Entity/LocalgovDirectoriesFacets.php
+++ b/src/Entity/LocalgovDirectoriesFacets.php
@@ -16,7 +16,7 @@ use Drupal\user\UserInterface;
  * @ContentEntityType(
  *   id = "localgov_directories_facets",
  *   label = @Translation("Directory Facets"),
- *   label_collection = @Translation("Directory Facetses"),
+ *   label_collection = @Translation("Directory Facets"),
  *   bundle_label = @Translation("Directory Facets type"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",


### PR DESCRIPTION
Just a trivial typo correction. Keeping my commits and PRs seperated by actual purpose and function ;-)