### PR TITLE
Apply embeded view facets to map attachment.

### DIFF
--- a/modules/localgov_directories_location/localgov_directories_location.services.yml
+++ b/modules/localgov_directories_location/localgov_directories_location.services.yml
@@ -1,0 +1,6 @@
+services:
+  localgov_directories_location.search_api_event_subscriber:
+    class: Drupal\localgov_directories_location\EventSubscriber\SearchApiSubscriber
+    arguments: ['@facets.manager']
+    tags:
+      - { name: event_subscriber }

--- a/modules/localgov_directories_location/src/EventSubscriber/SearchApiSubscriber.php
+++ b/modules/localgov_directories_location/src/EventSubscriber/SearchApiSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\localgov_directories_location\EventSubscriber;
+
+use Drupal\facets\FacetManager\DefaultFacetManager;
+use Drupal\search_api\Event\SearchApiEvents;
+use Drupal\search_api\Event\QueryPreExecuteEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Searh API events.
+ */
+class SearchApiSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Facet manager.
+   *
+   * @var \Drupal\facets\FacetManager\DefaultFacetManager
+   */
+  protected $facetManager;
+
+  /**
+   * SearchApiSubscriber constructor.
+   *
+   * @param \Drupal\facets\FacetManager\DefaultFacetManager $facet_manager
+   *   The facet manager.
+   */
+  public function __construct(DefaultFacetManager $facet_manager) {
+    $this->facetManager = $facet_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      SearchApiEvents::QUERY_PRE_EXECUTE => 'queryPreExecute',
+    ];
+  }
+
+  /**
+   * Reacts to the query pre-execute event.
+   *
+   * @param \Drupal\search_api\Event\QueryPreExecuteEvent $event
+   *   The query pre-execute event.
+   */
+  public function queryPreExecute(QueryPreExecuteEvent $event) {
+    $query = $event->getQuery();
+    // While we're just dealing with one view display by id this check isn't
+    // needed, but left here as harmless and generalizing the match is possibly
+    // desirable in the future.
+    if ($query->getIndex()->getServerInstance()->supportsFeature('search_api_facets')) {
+      $search_id = $query->getSearchId();
+      // This is the map attachment.
+      if ($search_id == 'views_attachment:localgov_directory_channel__node_embed_map_attachment') {
+        // Add the active filters from the search api view display for the list.
+        $this->facetManager->alterQuery($query, 'search_api:views_embed__localgov_directory_channel__node_embed');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
At present the facets embeded view of directory entries isn't filtering the map attachment at the same time as the list. This applies the facets from the embedded list to the map as well.

I'd pondered making this more general; but decided specific for this one case is good for now. When there are more maps it can decided to repeat this with them where ever they exist, or write a rule for naming patterns that makes it easy to apply the same rule to multiple views.

For now this fixes the immediate issue.