### PR TITLE
Better ignore for Facet Types, now with tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,15 @@ The content type should be automatically added to the search index when you add
 the directory fields. You may want to create a `directory index` display mode
 as this will be used for the full text search indexing.
 
+### Staging 'Directory facet types'
+
+By default facet types are not exported to configuration and are treated as
+content an administrator user can create on production. If you want to have
+types in configuration as vocabularies would be on the site to create and
+export the facet types set:
+`$settings['localgov_directories_stage_site'] = TRUE;`
+and it will be exported with other configuration. Any types that exist in
+configuration will be imported.
+
 ## Block placement
 When using a theme other than the localgov_theme, the **Directory channel search** (machine id: localgov_directories_channel_search_block) and **Directory facets** (machine id: facet_block:localgov_directories_facets) blocks should be made visible for the **Directory Channel** content type.  They can be added to a sidebar region (or equivalent) of the site theme.  Note that the facet_block:localgov_directories_facets block becomes available only after you have created at least one Directory entry content type.

--- a/localgov_directories.services.yml
+++ b/localgov_directories.services.yml
@@ -1,6 +1,6 @@
 services:
   localgov_directories.event_subscriber:
     class: Drupal\localgov_directories\EventSubscriber\DirectoriesConfigSubscriber
-    arguments: ['@config.storage.sync']
+    arguments: ['@config.storage', '@config.storage.sync']
     tags:
       - { name: event_subscriber }

--- a/src/EventSubscriber/DirectoriesConfigSubscriber.php
+++ b/src/EventSubscriber/DirectoriesConfigSubscriber.php
@@ -5,6 +5,7 @@ namespace Drupal\localgov_directories\EventSubscriber;
 use Drupal\Core\Config\ConfigEvents;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Config\StorageTransformEvent;
+use Drupal\Core\Site\Settings;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -13,20 +14,37 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class DirectoriesConfigSubscriber implements EventSubscriberInterface {
 
   /**
-   * The sync storage.
+   * Configuration prefixes to ignore.
+   *
+   * @var array
+   */
+  const PREFIXES = ['localgov_directories.localgov_directories_facets_type.'];
+
+  /**
+   * The active config storage.
    *
    * @var \Drupal\Core\Config\StorageInterface
    */
-  protected $sync;
+  protected $activeStorage;
+
+  /**
+   * The sync config storage.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $syncStorage;
 
   /**
    * DirectoriesConfigSubscriber constructor.
    *
-   * @param \Drupal\Core\Config\StorageInterface $sync
-   *   The sync storage.
+   * @param \Drupal\Core\Config\StorageInterface $config_storage
+   *   The config active storage.
+   * @param \Drupal\Core\Config\StorageInterface $sync_storage
+   *   The sync config storage.
    */
-  public function __construct(StorageInterface $sync) {
-    $this->sync = $sync;
+  public function __construct(StorageInterface $config_storage, StorageInterface $sync_storage) {
+    $this->activeStorage = $config_storage;
+    $this->syncStorage = $sync_storage;
   }
 
   /**
@@ -36,6 +54,23 @@ class DirectoriesConfigSubscriber implements EventSubscriberInterface {
    *   The config storage transform event.
    */
   public function onImportTransform(StorageTransformEvent $event) {
+    $transformation_storage = $event->getStorage();
+    $destination_storage = $this->activeStorage;
+
+    // If there is a configuration in the destination storage (the database)
+    // which is not in the transformation storage (from directory) don't delete
+    // it.
+    foreach (array_merge([StorageInterface::DEFAULT_COLLECTION], $this->activeStorage->getAllCollectionNames()) as $collection_name) {
+      $transformation_collection = $transformation_storage->createCollection($collection_name);
+      $destination_collection = $destination_storage->createCollection($collection_name);
+      foreach ($this->ignoreConfigNames($destination_storage) as $config_name) {
+        if (!$transformation_collection->exists($config_name) && $destination_collection->exists($config_name)) {
+          // Make sure the config is not removed if it exists.
+          $transformation_collection->write($config_name, $destination_collection->read($config_name));
+        }
+      }
+    }
+
   }
 
   /**
@@ -45,11 +80,49 @@ class DirectoriesConfigSubscriber implements EventSubscriberInterface {
    *   The config storage transform event.
    */
   public function onExportTransform(StorageTransformEvent $event) {
-    $sync = $this->sync->read('localgov_directories.localgov_directories_facets_type');
-    // Only change something if the sync storage has data.
-    if (!empty($sync)) {
-      $storage = $event->getStorage();
-      $storage->delete('localgov_directories.localgov_directories_facets_type');
+    // Export all changes if $settings['localgov_directories_stage_site'] = TRUE.
+    if (Settings::get('localgov_directories_stage_site')) {
+      return;
+    }
+
+    $transformation_storage = $event->getStorage();
+    $destination_storage = $this->syncStorage;
+
+    foreach (array_merge([StorageInterface::DEFAULT_COLLECTION], $transformation_storage->getAllCollectionNames()) as $collection_name) {
+      $transformation_collection = $transformation_storage->createCollection($collection_name);
+      $destination_collection = $destination_storage->createCollection($collection_name);
+      foreach ($this->ignoreConfigNames($transformation_collection) as $config_name) {
+        // If a configuration exists in the destination (configuration directory)
+        // already leave it as it is, even if there are changes in the
+        // transformation_storage (from the database).
+        if ($destination_collection->exists($config_name)) {
+          $transformation_collection->write($config_name, $destination_collection->read($config_name));
+        }
+        else {
+          // Otherwise the configuration does not exist in the destination
+          // (configuration directory) and should not be written to it from the
+          // transformation_storage (as it is in the database).
+          $transformation_collection->delete($config_name);
+        }
+      }
+    }
+
+  }
+
+  /**
+   * List all the configuration names to ignore in the storage.
+   *
+   * @param \Drupal\Core\Config\StorageInterface $storage
+   *   The config storage to retreive all the key names from.
+   *
+   * @return string[]
+   *   Yields the key names matching in the storage.
+   */
+  protected function ignoreConfigNames(StorageInterface $storage) {
+    foreach (self::PREFIXES as $prefix) {
+      foreach ($storage->listAll($prefix) as $name) {
+        yield $name;
+      }
     }
   }
 

--- a/src/EventSubscriber/DirectoriesConfigSubscriber.php
+++ b/src/EventSubscriber/DirectoriesConfigSubscriber.php
@@ -80,7 +80,8 @@ class DirectoriesConfigSubscriber implements EventSubscriberInterface {
    *   The config storage transform event.
    */
   public function onExportTransform(StorageTransformEvent $event) {
-    // Export all changes if $settings['localgov_directories_stage_site'] = TRUE.
+    // Export all changes if
+    // $settings['localgov_directories_stage_site'] = TRUE.
     if (Settings::get('localgov_directories_stage_site')) {
       return;
     }
@@ -92,9 +93,9 @@ class DirectoriesConfigSubscriber implements EventSubscriberInterface {
       $transformation_collection = $transformation_storage->createCollection($collection_name);
       $destination_collection = $destination_storage->createCollection($collection_name);
       foreach ($this->ignoreConfigNames($transformation_collection) as $config_name) {
-        // If a configuration exists in the destination (configuration directory)
-        // already leave it as it is, even if there are changes in the
-        // transformation_storage (from the database).
+        // If a configuration exists in the destination (configuration
+        // directory) already leave it as it is, even if there are changes in
+        // the transformation_storage (from the database).
         if ($destination_collection->exists($config_name)) {
           $transformation_collection->write($config_name, $destination_collection->read($config_name));
         }

--- a/tests/localgov_directories_facets_ignore_test/config/install/localgov_directories.localgov_directories_facets_type.test.yml
+++ b/tests/localgov_directories_facets_ignore_test/config/install/localgov_directories.localgov_directories_facets_type.test.yml
@@ -1,0 +1,5 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: 'Test Facet Type'

--- a/tests/localgov_directories_facets_ignore_test/localgov_directories_facets_ignore_test.info.yml
+++ b/tests/localgov_directories_facets_ignore_test/localgov_directories_facets_ignore_test.info.yml
@@ -1,0 +1,4 @@
+name: 'Directories Facet Type config ignore test'
+type: module
+package: Testing
+version: VERSION

--- a/tests/localgov_directories_facets_ignore_test/localgov_directories_facets_ignore_test.info.yml
+++ b/tests/localgov_directories_facets_ignore_test/localgov_directories_facets_ignore_test.info.yml
@@ -1,4 +1,3 @@
 name: 'Directories Facet Type config ignore test'
 type: module
 package: Testing
-version: VERSION

--- a/tests/src/Kernel/IgnoreTypeConfigTest.php
+++ b/tests/src/Kernel/IgnoreTypeConfigTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Tests DirectoriesConfigSubscriber.
+ *
+ * @group localgov_directories
+ */
+class IgnoreTypeConfigTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'localgov_directories',
+    'localgov_directories_facets_ignore_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['system', 'localgov_directories_facets_ignore_test']);
+  }
+
+  /**
+   * Test excluding modules from the config export.
+   */
+  public function testExcludedModules() {
+    // Assert that our facet config is in the active config.
+    $active = $this->container->get('config.storage');
+    $this->assertNotEmpty($active->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($active->listAll('system.'));
+    // Add collections.
+    $collection = $this->randomMachineName();
+    foreach ($active->listAll() as $config) {
+      $active->createCollection($collection)->write($config, $active->read($config));
+    }
+
+    // Assert that facet config is not in the export storage.
+    $export = $this->container->get('config.storage.export');
+    $this->assertEmpty($export->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($export->listAll('system.'));
+    // And assert excluded from collections too.
+    $this->assertEmpty($export->createCollection($collection)->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($export->createCollection($collection)->listAll('system.'));
+
+    // Assert that existing facet config is again in the import storage.
+    $import = $this->container->get('config.import_transformer')->transform($export);
+    $this->assertNotEmpty($import->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($import->listAll('system.'));
+
+    // Enable export.
+    $settings = Settings::getInstance() ? Settings::getAll() : [];
+    $settings['localgov_directories_stage_site'] = TRUE;
+    new Settings($settings);
+    drupal_flush_all_caches();
+    // Assert that facet config is in the export storage.
+    $export = $this->container->get('config.storage.export');
+    $this->assertNotEmpty($export->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($export->listAll('system.'));
+    // And assert excluded from collections too.
+    $this->assertNotEmpty($export->createCollection($collection)->listAll('localgov_directories.localgov_directories_facets_type.'));
+    $this->assertNotEmpty($export->createCollection($collection)->listAll('system.'));
+
+    // Assert config not removed if it exists in exported storage.
+    $settings = Settings::getInstance() ? Settings::getAll() : [];
+    $settings['localgov_directories_stage_site'] = FALSE;
+    new Settings($settings);
+    drupal_flush_all_caches();
+    $sync = $this->container->get('config.storage.sync');
+    $active = $this->container->get('config.storage');
+    // Store sync storage, and make changes to active storage.
+    $this->copyConfig($active, $sync);
+    $active_facet_type_config = $active->read('localgov_directories.localgov_directories_facets_type.test');
+    $active_facet_type_config['label'] = 'Updated';
+    $active->write('localgov_directories.localgov_directories_facets_type.test', $active_facet_type_config);
+    $active_system_config = $active->read('system.site');
+    $active_system_config['name'] = 'Updated';
+    $active->write('system.site', $active_system_config);
+    // Assert that facet config remains as is,
+    // but update to sytem is exported.
+    $export = $this->container->get('config.storage.export');
+    $export_facet_type_config = $export->read('localgov_directories.localgov_directories_facets_type.test');
+    $this->assertEquals($export_facet_type_config['label'], 'Test Facet Type');
+    $export_system_config = $export->read('system.site');
+    $this->assertEquals($export_system_config['name'], 'Updated');
+
+    // Assert config is imported if present.
+    $import = $this->container->get('config.import_transformer')->transform($export);
+    $import_facet_type_config = $import->read('localgov_directories.localgov_directories_facets_type.test');
+    $this->assertEquals($import_facet_type_config['label'], 'Test Facet Type');
+  }
+
+}


### PR DESCRIPTION
The previous built-in ignore for exporting facet type config was... uhum... a little brutal and so Drupal sometimes moaned about deleting the config; it also didn't take into account collections (mainly used for languages).

This update - with full tests - works better by replacing the configuration in the correct service with the live content. There's a quite full explanation on this 'blog' post I wrote https://gitlab.com/ekes/drupal-config-transform-event/-/blob/master/README.md The module there also has the full tests https://gitlab.com/ekes/drupal-config-transform-event 

Using this also makes it possible for sites to stage the facet types if they want. There is a $configuration setting that can be added. I've added a note about this is the readme.