### PR TITLE
Fix/52 map attachment embed

### DIFF
--- a/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
+++ b/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
@@ -181,36 +181,13 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:search_api.index.localgov_directories_index_default'
-  node_embed:
+  embed_map:
     display_plugin: embed
-    id: node_embed
-    display_title: Embed
-    position: 1
-    display_options:
-      display_extenders: {  }
-      cache:
-        type: none
-      defaults:
-        cache: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - 'user.node_grants:view'
-      tags:
-        - 'config:search_api.index.localgov_directories_index_default'
-  node_embed_map_attachment:
-    display_plugin: attachment
-    id: node_embed_map_attachment
-    display_title: Attachment
+    id: embed_map
+    display_title: 'Embed: map'
     position: 2
     display_options:
       display_extenders: {  }
-      displays:
-        node_embed: node_embed
-      inherit_exposed_filters: true
       relationships:
         localgov_location:
           id: localgov_location
@@ -439,22 +416,22 @@ display:
           leaflet_map: 'OSM Mapnik'
           height: '400'
           height_unit: px
-          hide_empty_map: 1
-          disable_wheel: 0
-          fullscreen_control: 1
-          gesture_handling: 0
+          hide_empty_map: true
+          disable_wheel: false
+          fullscreen_control: true
+          gesture_handling: false
           reset_map:
-            control: 0
+            control: false
             position: topright
           map_position:
-            force: 0
+            force: false
             center:
-              lat: '0'
-              lon: '0'
-            zoom: '12'
-            minZoom: '1'
-            maxZoom: '18'
-            zoomFiner: '0'
+              lat: 0
+              lon: 0
+            zoom: 12
+            minZoom: 1
+            maxZoom: 18
+            zoomFiner: 0
           icon:
             iconType: marker
             iconUrl: ''
@@ -479,18 +456,18 @@ display:
               'y': ''
           path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2"}'
           geocoder:
-            control: 0
+            control: false
             settings:
               position: topright
-              input_size: '25'
+              input_size: 25
               providers:
                 localgov_default_osm:
                   weight: '0'
                   checked: 0
-              min_terms: '4'
-              delay: '800'
-              zoom: '16'
-              popup: 0
+              min_terms: 4
+              delay: 800
+              zoom: 16
+              popup: false
               options: ''
       row:
         type: search_api
@@ -500,13 +477,51 @@ display:
               localgov_directories_page: teaser
               localgov_directories_venue: teaser
       empty: {  }
+      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.localgov_geo.location'
+        - 'config:search_api.index.localgov_directories_index_default'
+  node_embed:
+    display_plugin: embed
+    id: node_embed
+    display_title: 'Embed: list'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      cache:
+        type: none
+      defaults:
+        cache: false
+        empty: false
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No results were found.'
+            format: wysiwyg
+          plugin_id: text
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
         - 'config:search_api.index.localgov_directories_index_default'

--- a/modules/localgov_directories_location/localgov_directories_location.install
+++ b/modules/localgov_directories_location/localgov_directories_location.install
@@ -22,3 +22,32 @@ function localgov_directories_location_install() {
     $view->save();
   }
 }
+
+/**
+ * Add new map embed display, but do not enable it as default.
+ *
+ * It is advised that installations remove the old attachment and enable the
+ * new map embed field on the directory channel view mode.
+ */
+function localgov_directories_location_update_8001() {
+  // Retrieve view display mode config and add it to the existing configuration.
+  $view_with_map_embed = Yaml::decode(file_get_contents(drupal_get_path('module', 'localgov_directories_location') . '/config/override/views.view.localgov_directory_channel.yml'));
+  $view = View::load('localgov_directory_channel');
+  if ($view) {
+    $display = $view->get('display');
+    $display['embed_map'] = $view_with_map_embed['display']['embed_map'];
+    $view->set('display', $display);
+    $view->save();
+  }
+
+  // But don't enable it by default. This sets it as disabled before
+  // extra fields has even added it.
+  $directory_display_modes = \Drupal::service('entity_display.repository')
+    ->getViewModeOptionsByBundle('node', 'localgov_directory');
+  foreach (array_keys($directory_display_modes) as $display_id) {
+    $directory_display = \Drupal::entityTypeManager()
+      ->getStorage('entity_view_display')
+      ->load('node.localgov_directory.' . $display_id);
+    $directory_display->removeComponent('localgov_directory_map')->save();
+  }
+}

--- a/modules/localgov_directories_location/localgov_directories_location.install
+++ b/modules/localgov_directories_location/localgov_directories_location.install
@@ -17,7 +17,7 @@ function localgov_directories_location_install() {
   $view = View::load('localgov_directory_channel');
   if ($view) {
     $display = $view->get('display');
-    $display['embed_map'] = $view_with_map_embed['display']['emded_map'];
+    $display['embed_map'] = $view_with_map_embed['display']['embed_map'];
     $view->set('display', $display);
     $view->save();
   }

--- a/modules/localgov_directories_location/localgov_directories_location.install
+++ b/modules/localgov_directories_location/localgov_directories_location.install
@@ -13,11 +13,11 @@ use Drupal\views\Entity\View;
  */
 function localgov_directories_location_install() {
   // Retrieve view display mode config and add it to the existing configuration.
-  $view_with_attachment = Yaml::decode(file_get_contents(drupal_get_path('module', 'localgov_directories_location') . '/config/override/views.view.localgov_directory_channel.yml'));
+  $view_with_map_embed = Yaml::decode(file_get_contents(drupal_get_path('module', 'localgov_directories_location') . '/config/override/views.view.localgov_directory_channel.yml'));
   $view = View::load('localgov_directory_channel');
   if ($view) {
     $display = $view->get('display');
-    $display['node_embed_map_attachment'] = $view_with_attachment['display']['node_embed_map_attachment'];
+    $display['embed_map'] = $view_with_map_embed['display']['emded_map'];
     $view->set('display', $display);
     $view->save();
   }

--- a/modules/localgov_directories_location/localgov_directories_location.module
+++ b/modules/localgov_directories_location/localgov_directories_location.module
@@ -4,3 +4,23 @@
  * @file
  * Provides a location extension to directories.
  */
+
+use Drupal\localgov_directories_location\LocationExtraFieldDisplay;
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function localgov_directories_location_entity_extra_field_info() {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(LocationExtraFieldDisplay::class)
+    ->entityExtraFieldInfo();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function localgov_directories_location_node_view(array &$build, NodeInterface $node, EntityViewDisplayInterface $display, $view_mode) {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(LocationExtraFieldDisplay::class)
+    ->nodeView($build, $node, $display, $view_mode);
+}

--- a/modules/localgov_directories_location/localgov_directories_location.module
+++ b/modules/localgov_directories_location/localgov_directories_location.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\localgov_directories_location\LocationExtraFieldDisplay;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_extra_field_info().

--- a/modules/localgov_directories_location/src/EventSubscriber/SearchApiSubscriber.php
+++ b/modules/localgov_directories_location/src/EventSubscriber/SearchApiSubscriber.php
@@ -51,8 +51,8 @@ class SearchApiSubscriber implements EventSubscriberInterface {
     // desirable in the future.
     if ($query->getIndex()->getServerInstance()->supportsFeature('search_api_facets')) {
       $search_id = $query->getSearchId();
-      // This is the map attachment.
-      if ($search_id == 'views_attachment:localgov_directory_channel__node_embed_map_attachment') {
+      // This is the map to work with the list.
+      if ($search_id == 'views_embed:localgov_directory_channel__embed_map') {
         // Add the active filters from the search api view display for the list.
         $this->facetManager->alterQuery($query, 'search_api:views_embed__localgov_directory_channel__node_embed');
       }

--- a/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+++ b/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\localgov_directories_location;
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\views\Views;
+
+/**
+ * Adds views display for the directory channel.
+ */
+class LocationExtraFieldDisplay {
+
+  use StringTranslationTrait;
+
+  /**
+   * Gets the "extra fields" for a bundle.
+   *
+   * @see hook_entity_extra_field_info()
+   */
+  public function entityExtraFieldInfo() {
+    $fields = [];
+    $fields['node']['localgov_directory']['display']['localgov_directory_map'] = [
+      'label' => $this->t('Directory map'),
+      'description' => $this->t("Output from the embedded map view for this channel."),
+      'weight' => -20,
+      'visible' => TRUE,
+    ];
+
+    return $fields;
+  }
+
+  /**
+   * Adds view with arguments to view render array if required.
+   *
+   * @see localgov_directories_node_view()
+   */
+  public function nodeView(array &$build, NodeInterface $node, EntityViewDisplayInterface $display, $view_mode) {
+    // Add view if enabled.
+    if ($display->getComponent('localgov_directory_map')) {
+      $build['localgov_directory_map'] = $this->getViewEmbed($node);
+    }
+  }
+
+  /**
+   * Retrieves view, and sets render array.
+   */
+  protected function getViewEmbed(NodeInterface $node) {
+    $view = Views::getView('localgov_directory_channel');
+    if (!$view || !$view->access('embed_map')) {
+      return;
+    }
+    return [
+      '#type' => 'view',
+      '#name' => 'localgov_directory_channel',
+      '#display_id' => 'embed_map',
+      '#arguments' => [$node->id()],
+    ];
+  }
+
+}

--- a/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+++ b/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
@@ -24,7 +24,7 @@ class LocationExtraFieldDisplay {
     $fields['node']['localgov_directory']['display']['localgov_directory_map'] = [
       'label' => $this->t('Directory map'),
       'description' => $this->t("Output from the embedded map view for this channel."),
-      'weight' => -20,
+      'weight' => 0,
       'visible' => TRUE,
     ];
 


### PR DESCRIPTION
To deal with the preprocess being run before an attachment gets its arguments #52 This changes the attachment to an embed. Adds it as an additional field (as the list). And applies the facets from the list to the embed (as #50 did for the attachment).