### PR TITLE
Don't try to access missing facet in preprocess.

### DIFF
--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -251,7 +251,7 @@ function localgov_directories_field_config_delete(FieldConfigInterface $field) {
  * @see facets_preprocess_facets_item_list()
  */
 function localgov_directories_preprocess_facets_item_list(array &$variables) {
-  if ($variables['facet']->id() == 'localgov_directories_facets') {
+  if (!empty($variables['facet']) && ($variables['facet']->id() == 'localgov_directories_facets')) {
     \Drupal::service('class_resolver')
       ->getInstanceFromDefinition(DirectoryExtraFieldDisplay::class)
       ->preprocessFacetList($variables);


### PR DESCRIPTION
Not something that's going to happen in LocalGov as is I don't think, because you have to add facets to a channel. I'll make another patch for allowing people not to :)

But, if you've edited the config and allow a directory with no (or different) facets and this is called when the facet hasn't been added at all before preprocess it'll through an fatal access method on null.