### PR TITLE
Bug fix: corrects required issue where values lost, make required work

### DIFF
--- a/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesChannelsSelection.php
+++ b/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesChannelsSelection.php
@@ -2,8 +2,14 @@
 
 namespace Drupal\localgov_directories\Plugin\EntityReferenceSelection;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Plugin description.
@@ -21,13 +27,27 @@ class LocalgovDirectoriesChannelsSelection extends DefaultSelection {
   /**
    * {@inheritdoc}
    */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager = NULL, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, EntityRepositoryInterface $entity_repository = NULL) {
+    $configuration['target_bundles'] = NULL;
+    $configuration['auto_create'] = NULL;
+    $configuration['auto_create_bundle'] = NULL;
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $module_handler, $current_user, $entity_field_manager, $entity_type_bundle_info, $entity_repository);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function defaultConfiguration() {
-    return [
+    $config = [
       'sort' => [
         'field' => '_none',
         'direction' => 'ASC',
       ],
     ] + parent::defaultConfiguration();
+    unset($config['target_bundles']);
+    unset($config['auto_create']);
+    unset($config['auto_create_bundle']);
+    return $config;
   }
 
   /**
@@ -39,6 +59,18 @@ class LocalgovDirectoriesChannelsSelection extends DefaultSelection {
     unset($form['auto_create']);
     unset($form['auto_create_bundle']);
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::validateConfigurationForm($form, $form_state);
+
+    // If the js didn't update the form.
+    $form_state->unsetValue(['settings', 'handler_settings', 'target_bundles']);
+    $form_state->unsetValue(['settings', 'handler_settings', 'auto_create']);
+    $form_state->unsetValue(['settings', 'handler_settings', 'auto_create_bundle']);
   }
 
   /**

--- a/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesChannelsSelection.php
+++ b/src/Plugin/EntityReferenceSelection/LocalgovDirectoriesChannelsSelection.php
@@ -70,7 +70,11 @@ class LocalgovDirectoriesChannelsSelection extends DefaultSelection {
     // If the js didn't update the form.
     $form_state->unsetValue(['settings', 'handler_settings', 'target_bundles']);
     $form_state->unsetValue(['settings', 'handler_settings', 'auto_create']);
-    $form_state->unsetValue(['settings', 'handler_settings', 'auto_create_bundle']);
+    $form_state->unsetValue([
+      'settings',
+      'handler_settings',
+      'auto_create_bundle',
+    ]);
   }
 
   /**

--- a/src/Plugin/Field/FieldWidget/ChannelFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/ChannelFieldWidget.php
@@ -81,9 +81,16 @@ class ChannelFieldWidget extends OptionsWidgetBase {
    */
   public static function validateElement(array $element, FormStateInterface $form_state) {
     // Flatten the array again.
-    $values = $form_state->getValue($element['#field_name']);
+    if ($form_state->get('default_value_widget')) {
+      $values = $form_state->getValue('default_value_input')[$element['#field_name']];
+    }
+    else {
+      $values = $form_state->getValue($element['#field_name']);
+    }
     if ($values) {
-      $element['#value'] = [$values['primary'] => $values['primary']] + $values['secondary'];
+      $element['#value'] = array_filter(
+        [$values['primary'] => $values['primary']] + $values['secondary']
+      );
     }
 
     parent::validateElement($element, $form_state);

--- a/src/Plugin/Field/FieldWidget/FacetFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/FacetFieldWidget.php
@@ -52,7 +52,6 @@ class FacetFieldWidget extends OptionsWidgetBase {
         $bundle_label => $options,
       ];
     }
-    $selected = $this->getSelectedOptions($items);
 
     $enabled = [];
     if ($user_input = $form_state->getValue('localgov_directory_channels')) {
@@ -78,12 +77,18 @@ class FacetFieldWidget extends OptionsWidgetBase {
         }
       }
     }
+
     // And only allow bundles associated with the channels.
     $options = array_intersect_key($options, $enabled);
 
+    // Set selected from any existing values.
+    $selected = $this->getSelectedOptions($items);
+    // If there is only one option and it's required default it.
     if ($this->required && count($options) == 1) {
-      reset($options);
-      $selected = [key($options)];
+      $single_bundle_options = reset($options);
+      if (count($single_bundle_options) == 1) {
+        $selected = [key($single_bundle_options)];
+      }
     }
 
     $element += [
@@ -122,9 +127,15 @@ class FacetFieldWidget extends OptionsWidgetBase {
       $element['#value'] = [];
       foreach ($values as $options) {
         foreach ($options as $key => $value) {
-          $element['#value'][$key] = $value;
+          if ($value) {
+            $element['#value'][$key] = $value;
+          }
         }
       }
+    }
+    // None option.
+    if (empty($element['#value'])) {
+      $element['#value'] = '_none';
     }
 
     parent::validateElement($element, $form_state);

--- a/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
+++ b/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field_ui\Traits\FieldUiTestTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests the configuration of channel widget.
+ *
+ * @group localgov_directories
+ */
+class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
+
+  use FieldUiTestTrait;
+  use ContentTypeCreationTrait;
+  use EntityReferenceTestTrait;
+  use NodeCreationTrait;
+
+  /**
+   * A user with mininum permissions for test.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'localgov_directories',
+    'field_ui',
+    'block',
+  ];
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->drupalPlaceBlock('system_breadcrumb_block');
+    $this->drupalPlaceBlock('local_actions_block');
+    $this->drupalPlaceBlock('local_tasks_block');
+    $this->drupalPlaceBlock('page_title_block');
+
+    for ($j = 1; $j < 3; $j++) {
+      $directory = $this->createNode([
+        'title' => 'Directory ' . $j,
+        'type' => 'localgov_directory',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_facets_enable' => [],
+      ]);
+      $directory->save();
+      $this->directories[$j] = $directory;
+    }
+
+    // Content type configured to reference directories, and have the
+    // facet selector.
+    $this->createContentType(['type' => 'entry_1']);
+    $this->createContentType(['type' => 'entry_2']);
+
+    // Configure directory channels to allow different entry types.
+    $this->directories[1]->localgov_directory_channel_types = [
+      'target_id' => 'entry_1',
+    ];
+    $this->directories[1]->save();
+    $this->directories[2]->localgov_directory_channel_types = [
+      ['target_id' => 'entry_1'],
+      ['target_id' => 'entry_2'],
+    ];
+    $this->directories[2]->save();
+
+    // Create a test user.
+    $admin_user = $this->drupalCreateUser([
+      'access content',
+      'administer content types',
+      'administer node fields',
+      'administer node form display',
+      'administer node display',
+      'bypass node access',
+    ]);
+    $this->drupalLogin($admin_user);
+  }
+
+  /**
+   * Test selecting channels and facets appearing.
+   */
+  public function testDirectoryChannelWidget() {
+    // Create the fields with the selector.
+    $this->fieldUIAddNewField(
+      'admin/structure/types/manage/entry_1',
+      'channels',
+      'Channels',
+      'field_ui:entity_reference:node',
+      [],
+      [
+        'settings[handler]' => 'localgov_directories_channels_selection',
+        // No javascript update; and fieldUIAddNewField is too fast for it with.
+        'settings[handler_settings][target_bundles][localgov_directory]' => TRUE,
+      ]
+    );
+    $this->fieldUIAddExistingField(
+      'admin/structure/types/manage/entry_2',
+      'field_channels',
+      'Channels',
+      [
+        'settings[handler]' => 'localgov_directories_channels_selection',
+        // No javascript update; and fieldUIAddNewField is too fast for it with.
+        'settings[handler_settings][target_bundles][localgov_directory]' => TRUE,
+      ]
+    );
+    // Set the widget.
+    $this->drupalPostForm('/admin/structure/types/manage/entry_1/form-display', ['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
+    $this->drupalPostForm('/admin/structure/types/manage/entry_2/form-display', ['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
+
+    // Check the correct channels are on the different entry forms.
+    $this->drupalGet('/node/add/entry_1');
+    $assert_session = $this->assertSession();
+    $assert_session->pageTextContains('Directory 1');
+    $assert_session->pageTextContains('Directory 2');
+    $this->drupalGet('/node/add/entry_2');
+    $assert_session->pageTextNotContains('Directory 1');
+    $assert_session->pageTextContains('Directory 2');
+
+    // Set a default.
+    $this->drupalPostForm(
+      '/admin/structure/types/manage/entry_1/fields/node.entry_1.field_channels',
+      [
+        'default_value_input[field_channels][primary]' => $this->directories[2]->id(),
+      ],
+      'edit-submit'
+    );
+    $this->drupalGet('/admin/structure/types/manage/entry_1/fields/node.entry_1.field_channels');
+    $this->drupalPostForm(
+      '/admin/structure/types/manage/entry_2/fields/node.entry_2.field_channels',
+      [
+        'default_value_input[field_channels][primary]' => $this->directories[2]->id(),
+      ],
+      'edit-submit'
+    );
+
+    // Check default applied.
+    $this->drupalGet('/node/add/entry_1');
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+    $radio = $page->findField('field_channels[primary]');
+    $this->assertEqual($radio->getValue(), $this->directories[2]->id());
+    $this->drupalGet('/node/add/entry_2');
+    $radio = $page->findField('field_channels[primary]');
+    $this->assertEqual($radio->getValue(), $this->directories[2]->id());
+    $assert_session->fieldNotExists('edit-field-channels-secondary-1');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
+++ b/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\localgov_directories\FunctionalJavascript;
 
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
@@ -51,6 +52,7 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
   protected function setUp() {
     parent::setUp();
 
+    // Three bundles of five facets.
     for ($i = 0; $i < 3; $i++) {
       $type_id = $this->randomMachineName();
       $type = LocalgovDirectoriesFacetsType::create(['id' => $type_id, 'label' => $type_id]);
@@ -62,7 +64,17 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
         $this->facets[$type_id][$facet->id()] = $facet;
       }
     }
+    // Another bundle with just one facet.
+    $type = LocalgovDirectoriesFacetsType::create(['id' => 'facetbundleonefacet', 'label' => 'facetbundleonefacet']);
+    $type->save();
+    $this->facet_types['facetbundleonefacet'] = $type;
+    $facet = LocalgovDirectoriesFacets::create(['bundle' => 'facetbundleonefacet', 'title' => $this->randomMachineName()]);
+    $facet->save();
+    $this->facets['facetbundleonefacet'][$facet->id()] = $facet;
 
+    // Directory 1
+    // Single facet bundle.
+    reset($this->facet_types);
     $directory = $this->createNode([
       'title' => 'Directory 1',
       'type' => 'localgov_directory',
@@ -73,6 +85,9 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
     ]);
     $directory->save();
     $this->directories['single_facet'] = $directory;
+
+    // Directory 2.
+    // All facet bundles.
     $all_enabled = [];
     foreach ($this->facet_types as $type_id => $type) {
       $all_enabled[] = ['target_id' => $type_id];
@@ -86,6 +101,32 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
     $directory->save();
     $this->directories['all_facets'] = $directory;
 
+    // Directory 3.
+    // Single facet with only one value.
+    $directory = $this->createNode([
+      'title' => 'Directory 3',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_directory_facets_enable' => [
+        ['target_id' => 'facetbundleonefacet'],
+      ],
+    ]);
+    $directory->save();
+    $this->directories['single_facet_single_value'] = $directory;
+
+    // Directory 4.
+    // No facets.
+    $directory = $this->createNode([
+      'title' => 'Directory 4',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_directory_facets_enable' => [],
+    ]);
+    $directory->save();
+    $this->directories['no_facets'] = $directory;
+
+    // Content type configured to reference directories, and have the
+    // facet selector.
     $this->createContentType(['type' => 'entry']);
     $display_repository = \Drupal::service('entity_display.repository');
     assert($display_repository instanceof EntityDisplayRepositoryInterface);
@@ -119,9 +160,10 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
     ]);
     $form_display->save();
 
+    // User that can create entries.
     $this->user = $this->drupalCreateUser([
       'access content',
-      'create entry content',
+      'bypass node access',
     ]);
     $this->drupalLogin($this->user);
   }
@@ -156,13 +198,92 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
     $radio->click();
     $assert_session->assertWaitOnAjaxRequest();
     // Check all facets appear.
+    // Select them, and submit.
     $assert_session->elementExists('css', '[data-drupal-selector="edit-localgov-directory-facets-select-' . strtolower($facet_not_enabled) . '"]');
     foreach ($this->facets as $facet_types) {
       foreach ($facet_types as $facet) {
         $assert_session->fieldExists($facet->label());
+        $current_facet = $entry->findField($facet->label());
+        $current_facet->click();
+      }
+    }
+    $title = $this->randomString();
+    $entry->fillField('title[0][value]', $title);
+    $entry->pressButton('edit-submit');
+    // Ensure it's posted.
+    $assert_session->pageTextContains('entry ' . $title . ' has been created.');
+    $this->drupalGet('node/5/edit');
+    $entry = $this->getSession()->getPage();
+    // Ensure the channel and facets are selected.
+    $radio = $entry->findField('edit-localgov-directory-channels-secondary-' . $this->directories['all_facets']->id());
+    $this->assertTrue($radio->isChecked());
+    $assert_session->elementExists('css', '[data-drupal-selector="edit-localgov-directory-facets-select-' . strtolower($facet_not_enabled) . '"]');
+    foreach ($this->facets as $facet_types) {
+      foreach ($facet_types as $facet) {
+        $current_facet = $entry->findField($facet->label());
+        $this->assertTrue($current_facet->isChecked());
       }
     }
 
+    // Enable a channel with no facets.
+    // Ensure it saves.
+    $this->drupalGet('node/add/entry');
+    $entry = $this->getSession()->getPage();
+    $radio = $entry->findField('edit-localgov-directory-channels-secondary-' . $this->directories['no_facets']->id());
+    $radio->click();
+    $assert_session->assertWaitOnAjaxRequest();
+    $title = $this->randomString();
+    $entry->fillField('title[0][value]', $title);
+    $entry->pressButton('edit-submit');
+    // Ensure it's posted.
+    $assert_session->pageTextContains('entry ' . $title . ' has been created.');
+  }
+
+  /**
+   * Test if the facet field is required.
+   */
+  public function testFacetRequired() {
+    // Set the field to be required.
+    $facet_field = FieldConfig::loadByName('node', 'entry', 'localgov_directory_facets_select');
+    $facet_field->set('required', TRUE);
+    $facet_field->save();
+    $this->resetAll();
+    $facet_field = FieldConfig::loadByName('node', 'entry', 'localgov_directory_facets_select');
+    $this->assertTrue($facet_field->isRequired());
+
+    $this->drupalGet('node/add/entry');
+    $entry = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    // Select the single value facet channel.
+    // And check it is default selected as the only option on a required
+    // field.
+    $radio = $entry->findField('edit-localgov-directory-channels-primary-' . $this->directories['single_facet_single_value']->id());
+    $radio->click();
+    $assert_session->assertWaitOnAjaxRequest();
+    $facet_type_enabled = $this->directories['single_facet_single_value']->localgov_directory_facets_enable->first()->target_id;
+    $assert_session->elementExists('css', '[data-drupal-selector="edit-localgov-directory-facets-select-' . strtolower($facet_type_enabled) . '"]');
+    foreach ($this->facets['facetbundleonefacet'] as $facet) {
+      $assert_session->fieldExists($facet->label());
+      $single_facet = $entry->findField($facet->label());
+      $this->assertTrue($single_facet->isChecked());
+    }
+    $title = $this->randomString();
+    $entry->fillField('title[0][value]', $title);
+    $entry->pressButton('edit-submit');
+    $assert_session->pageTextContains('entry ' . $title . ' has been created.');
+
+    // Select a multiple value facet channel.
+    // Check that a field must be filled in.
+    $this->drupalGet('node/add/entry');
+    $entry = $this->getSession()->getPage();
+    $radio = $entry->findField('edit-localgov-directory-channels-primary-' . $this->directories['all_facets']->id());
+    $radio->click();
+    $assert_session->assertWaitOnAjaxRequest();
+    $title = $this->randomString();
+    $entry->fillField('title[0][value]', $title);
+    $entry->pressButton('edit-submit');
+    $assert_session->pageTextContains('localgov_directory_facets_select field is required.');
   }
 
 }


### PR DESCRIPTION
When required the facet field lost values. It should have set the default to a single facet enabled, if there was only one.

Also required didn't actually stop the submission of the form with no facets selected.

Fixes and extended tests for different variants. Also adds if there are no facets available on a channel.