### PR TITLE
PHP version fix for github runners localgovdrupal/.github/pull/4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Is this the same thing as https://github.com/localgovdrupal/.github Would it work as a subrepo or something?

Let's see if it passes.