### PR TITLE
Group add directory content links together if menu link groups is enabled

### DIFF
--- a/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_directory.yml
+++ b/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_directory.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - localgov_directories
+      - localgov_menu_link_group
+id: localgov_menu_link_group_directory
+group_label: Directory
+weight: 0
+parent_menu: admin
+parent_menu_link: 'admin_toolbar_tools.extra_links:node.add'
+child_menu_links:
+  - 'admin_toolbar_tools.extra_links:node.add.localgov_directory'
+  - 'admin_toolbar_tools.extra_links:node.add.localgov_directories_page'
+  - 'admin_toolbar_tools.extra_links:node.add.localgov_directories_venue'


### PR DESCRIPTION
This pr adds the optional localgov_menu_link_groups config to localgov_directories per this issue:

https://github.com/localgovdrupal/localgov/issues/119

Config for the other relevant modules and a functional javascript test for localgov_services is also ready.

