### PR TITLE
Hide duplicate exposed filter form

### DIFF
--- a/css/search-block.css
+++ b/css/search-block.css
@@ -5,6 +5,7 @@
 
 /* Hide the Directory search exposed form when rendered outside our block. */
 .view-localgov-directory-channel.view-display-id-node_embed > .view-filters,
+.view-localgov-directory-channel.view-display-id-embed_map > .view-filters,
 :not(.block-localgov-directories-channel-search-block) > .views-exposed-form.localgov-search-channel-primary,
 :not(.block-localgov-directories-channel-search-block) > .views-exposed-form.localgov-search-channel-secondary {
   display: none;

--- a/src/Plugin/Block/ChannelSearchBlock.php
+++ b/src/Plugin/Block/ChannelSearchBlock.php
@@ -132,6 +132,7 @@ class ChannelSearchBlock extends BlockBase implements ContainerFactoryPluginInte
       ->disableRedirect();
 
     $views_exposed_filter_form = $this->formBuilder->buildForm(ViewsExposedForm::class, $form_state);
+    $views_exposed_filter_form['#id'] .= '-in-a-search-block';
     return $views_exposed_filter_form;
   }
 


### PR DESCRIPTION
When the exposed filter form *block* for the Directory listing view is already
present in the page, do not display another similar exposed filter form above the **Map** display of
that view.

In other words, we are ending up with two similar Exposed filter forms - one from the Exposed filter form **block** in the sidebar, another from the Map display of the localgov_directory_channel view.  This change hides the second one.