### PR TITLE
Update composer dependencies to non-alpha localgov modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
-        "localgovdrupal/localgov_core": "^1.0@alpha",
-        "localgovdrupal/localgov_geo": "^1.0@alpha"
+        "localgovdrupal/localgov_core": "^1.0",
+        "localgovdrupal/localgov_geo": "^1.0"
     },
     "require-dev": {
-        "localgovdrupal/localgov_services": "1.0.0-alpha1"
+        "localgovdrupal/localgov_services": "^1.0"
     }
 }


### PR DESCRIPTION
Further to localgovdrupal/localgov#200 tidy up composer dependencies to the now existing 1.x versions.