### PR TITLE
Directory map view: Removing the Views pager

### DIFF
--- a/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
+++ b/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
@@ -206,6 +206,7 @@ display:
         style: false
         row: false
         empty: false
+        pager: false
       fields:
         title:
           id: title
@@ -478,6 +479,10 @@ display:
               localgov_directories_venue: teaser
       empty: {  }
       display_description: ''
+      pager:
+        type: none
+        options:
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
The map should display *all* markers and not just the ones on the current page.

Resolves #97 