### PR TITLE
Set directory channel, page and venue summary form fields to always be visible

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_directory.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_directory.default.yml
@@ -21,7 +21,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
@@ -103,7 +103,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
@@ -119,7 +119,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:


### PR DESCRIPTION
This PR makes the summary field always visible in the directory channel, page and venue back-end forms.

Closes #19 