### PR TITLE
Add title field for sort, remove some 'stopwords' from the sort.

### DIFF
--- a/config/install/search_api.index.localgov_directories_index_default.yml
+++ b/config/install/search_api.index.localgov_directories_index_default.yml
@@ -7,8 +7,9 @@ dependencies:
     - search_api.server.localgov_directories_default
     - core.entity_view_mode.node.directory_index
   module:
-    - search_api
     - node
+    - search_api
+    - localgov_directories
 id: localgov_directories_index_default
 name: Directories
 description: ''
@@ -33,6 +34,14 @@ field_settings:
         'entity:node':
           localgov_directories_page: directory_index
           node: directory_index
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: string
+    dependencies:
+      module:
+        - node
 datasource_settings:
   'entity:node':
     bundles:
@@ -50,10 +59,36 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
+      - title
     weights:
       preprocess_index: -20
       preprocess_query: -20
   language_with_fallback: {  }
+  localgov_string_stopwords:
+    all_fields: false
+    fields:
+      - title
+    stopwords:
+      - a
+      - an
+      - and
+      - for
+      - if
+      - in
+      - into
+      - of
+      - 'on'
+      - or
+      - s
+      - t
+      - that
+      - the
+      - this
+      - to
+      - was
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
   rendered_item: {  }
   stemmer:
     all_fields: true
@@ -112,6 +147,7 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
+    ignored: ._-
     spaces: ''
     overlap_cjk: 1
     minimum_word_size: '3'
@@ -122,6 +158,7 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
+      - title
     weights:
       preprocess_index: -20
       preprocess_query: -20

--- a/config/install/views.view.localgov_directory_channel.yml
+++ b/config/install/views.view.localgov_directory_channel.yml
@@ -189,7 +189,19 @@ display:
           min_length: null
           fields: {  }
           plugin_id: search_api_fulltext
-      sorts: {  }
+      sorts:
+        title:
+          id: title
+          table: search_api_index_localgov_directories_index_default
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
       header: {  }
       footer: {  }
       empty: {  }

--- a/config/schema/localgov_directories.processor.schema.yml
+++ b/config/schema/localgov_directories.processor.schema.yml
@@ -1,0 +1,13 @@
+# search_api processors
+
+plugin.plugin_configuration.search_api_processor.localgov_string_stopwords:
+  type: search_api.fields_processor_configuration
+  label: 'Stopwords in Strings processor configuration'
+  mapping:
+    stopwords:
+      type: sequence
+      label: 'Entered stopwords'
+      orderby: value
+      sequence:
+        type: string
+        label: Stopword

--- a/src/Plugin/search_api/processor/Stopwords.php
+++ b/src/Plugin/search_api/processor/Stopwords.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\localgov_directories\Plugin\search_api\processor;
+
+use Drupal\search_api\Processor\FieldsProcessorPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Allows you to define stopwords which will be ignored in strings used for sorting.
+ *
+ * @SearchApiProcessor(
+ *   id = "localgov_string_stopwords",
+ *   label = @Translation("Stopwords in strings"),
+ *   description = @Translation("Allows you to define stopwords which will be ignored in a string field."),
+ *   stages = {
+ *     "pre_index_save" = 0,
+ *     "preprocess_index" = -5,
+ *     "preprocess_query" = -2,
+ *   }
+ * )
+ */
+class Stopwords extends FieldsProcessorPluginBase {
+
+  /**
+   * An array whose keys and values are the stopwords set for this processor.
+   *
+   * @var string[]
+   */
+  protected $stopwords;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    $configuration = parent::defaultConfiguration();
+
+    $configuration += [
+      'stopwords' => [
+        'a', 'an', 'and', 'for', 'if', 'in', 'into', 'of', 'on', 'or', 's',
+        't', 'that', 'the', 'this', 'to', 'was',
+      ],
+    ];
+
+    return $configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    parent::setConfiguration($configuration);
+    unset($this->stopwords);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $stopwords = $this->getConfiguration()['stopwords'];
+    if (is_array($stopwords)) {
+      $default_value = implode("\n", $stopwords);
+    }
+    else {
+      $default_value = $stopwords;
+    }
+    $description = $this->t('Enter a list of stopwords, each on a separate line, that will be removed from content before it is indexed. <a href=":url">More info about stopwords.</a>.', [':url' => 'https://en.wikipedia.org/wiki/Stop_words']);
+
+    $form['stopwords'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Stopwords'),
+      '#description' => $description,
+      '#default_value' => $default_value,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    // Convert our text input to an array.
+    $form_state->setValue('stopwords', array_filter(array_map('trim', explode("\n", $form_state->getValues()['stopwords'])), 'strlen'));
+
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function testType($type) {
+    return $this->getDataTypeHelper()->isTextType($type, ['string']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function process(&$value) {
+    $stopwords = $this->getStopWords();
+    if (empty($stopwords) || !is_string($value)) {
+      return;
+    }
+    $value = preg_replace($stopwords, '', $value);
+    return trim($value);
+  }
+
+  /**
+   * Gets the stopwords for this processor.
+   *
+   * @return string[]
+   *   An array whose keys and values are the stopwords set for this processor.
+   */
+  protected function getStopWords() {
+    if (!isset($this->stopwords)) {
+      $stopwords = $this->configuration['stopwords'];
+      array_walk($stopwords, function (&$word) {
+        $word = '/(\s|^)' . $word . '\s/i';
+      });
+      $this->stopwords = array_combine($this->configuration['stopwords'], $stopwords);
+    }
+    return $this->stopwords;
+  }
+
+}

--- a/tests/src/Unit/Processor/StopwordsTest.php
+++ b/tests/src/Unit/Processor/StopwordsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories\Unit\Processor;
+
+use Drupal\localgov_directories\Plugin\search_api\processor\Stopwords;
+use Drupal\Tests\search_api\Unit\Processor\ProcessorTestTrait;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the "Stopwords in Strings" processor.
+ *
+ * @covers \Drupal\localgov_directories\Plugin\search_api\processor\Stopwords
+ * @group localgov_directories
+ */
+class StopwordsTest extends UnitTestCase {
+
+  use ProcessorTestTrait;
+
+  /**
+   * Creates a new processor object for use in the tests.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->processor = new Stopwords([], 'localgov_string_stopwords', []);
+  }
+
+  /**
+   * Tests the process() method of the Stopwords processor.
+   *
+   * @param string $passed_value
+   *   The string that should be passed to process().
+   * @param string $expected_value
+   *   The expected altered string.
+   * @param string[] $stopwords
+   *   The stopwords with which to configure the test processor.
+   *
+   * @dataProvider processDataProvider
+   */
+  public function testProcess($passed_value, $expected_value, array $stopwords) {
+    $this->processor->setConfiguration(['stopwords' => $stopwords]);
+    $this->invokeMethod('process', [&$passed_value]);
+    $this->assertEquals($expected_value, $passed_value);
+  }
+
+  /**
+   * Data provider for testStopwords().
+   *
+   * Processor checks for exact case, and tokenized content.
+   */
+  public function processDataProvider() {
+    return [
+      [
+        'the',
+        '',
+        ['the'],
+      ],
+      [
+        'theme',
+        'theme',
+        ['the'],
+      ],
+      [
+        'bathe',
+        'bathe',
+        ['the'],
+      ],
+      [
+        'bother',
+        'bother',
+        ['the'],
+      ],
+      [
+        'the theme',
+        'theme',
+        ['the'],
+      ],
+      [
+        'the first the bother',
+        'first bother',
+        ['the'],
+      ],
+      [
+        'ÄÖÜÀÁ<>»«û',
+        'ÄÖÜÀÁ<>»«û',
+        ['stopword1', 'ÄÖÜÀÁ<>»«', 'stopword3'],
+      ],
+      [
+        'ÄÖÜÀÁ',
+        '',
+        ['stopword1', 'ÄÖÜÀÁ', 'stopword3'],
+      ],
+      [
+        'ÄÖÜÀÁ stopword1',
+        '',
+        ['stopword1', 'ÄÖÜÀÁ', 'stopword3'],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Adds a filter before indexing the (now added) title field that remove 'The' 'A' etc. (configurable). This field then used for the alphabetical sort of the items.

Unit Test failing locally; but rumour has it might work... Let's see.