### PR TITLE
2.0.1 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE}-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
         
   phpcs:
     name: Coding standards checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
-          
+
       - name: Set composer branch reference for version branches
         if: endsWith(github.ref, '.x')
         run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -76,7 +76,7 @@ jobs:
 
       - name: Obtain the test target from the repo that triggered this workflow
         run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
-        
+
   phpcs:
     name: Coding standards checks
     needs: build
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
@@ -168,7 +168,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
           restore-keys: |
             localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 

--- a/config/install/core.entity_form_display.node.localgov_directory.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_directory.default.yml
@@ -21,7 +21,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/config/install/core.entity_view_display.node.localgov_directory.search_index.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.search_index.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_directory_channel_types
+    - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - node.type.localgov_directory
+  module:
+    - text
+    - user
+id: node.localgov_directory.search_index
+targetEntityType: node
+bundle: localgov_directory
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  localgov_directory_facets_enable:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  localgov_services_parent:
+    type: entity_reference_label
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+hidden:
+  links: true
+  localgov_directory_channel_types: true
+  localgov_directory_facets: true
+  localgov_directory_map: true
+  localgov_directory_view: true
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_directory_channel_types
+    - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - node.type.localgov_directory
+  module:
+    - text
+    - user
+id: node.localgov_directory.search_result
+targetEntityType: node
+bundle: localgov_directory
+mode: search_result
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 0
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+hidden:
+  links: true
+  localgov_directory_channel_types: true
+  localgov_directory_facets: true
+  localgov_directory_facets_enable: true
+  localgov_directory_map: true
+  localgov_directory_view: true
+  localgov_services_parent: true
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_directory.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.teaser.yml
@@ -18,22 +18,16 @@ content:
   body:
     label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    weight: 0
     settings:
       trim_length: 600
     third_party_settings: {  }
     region: content
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-  localgov_directory_view:
-    weight: -20
-    settings: {  }
-    third_party_settings: {  }
-    region: content
 hidden:
+  links: true
   localgov_directory_channel_types: true
+  localgov_directory_facets: true
   localgov_directory_facets_enable: true
+  localgov_directory_map: true
+  localgov_directory_view: true
   search_api_excerpt: true

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -68,3 +68,19 @@ function localgov_directories_update_8001() {
   $dir_facet_config->set('processor_configs', $facet_processor_configs);
   $dir_facet_config->save(TRUE);
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Renames the Directory label to Channels and facets.
+ */
+function localgov_directories_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('core.entity_form_display.node.localgov_directories_page.default');
+  $config->set('third_party_settings.field_group.group_directory.label', 'Channels and facets');
+  $config->save(TRUE);
+
+  $config = $config_factory->getEditable('core.entity_form_display.node.localgov_directories_venue.default');
+  $config->set('third_party_settings.field_group.group_directory.label', 'Channels and facets');
+  $config->save(TRUE);
+}

--- a/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
+++ b/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
@@ -206,6 +206,7 @@ display:
         style: false
         row: false
         empty: false
+        pager: false
       fields:
         title:
           id: title
@@ -478,6 +479,10 @@ display:
               localgov_directories_venue: teaser
       empty: {  }
       display_description: ''
+      pager:
+        type: none
+        options:
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
@@ -90,7 +90,7 @@ third_party_settings:
         description: ''
         formatter: closed
         required_fields: true
-      label: Directory
+      label: Channels and facets
 id: node.localgov_directories_page.default
 targetEntityType: node
 bundle: localgov_directories_page

--- a/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
@@ -103,7 +103,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_index.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_index.yml
@@ -1,0 +1,113 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_directory_address
+    - field.field.node.localgov_directories_page.localgov_directory_channels
+    - field.field.node.localgov_directories_page.localgov_directory_email
+    - field.field.node.localgov_directories_page.localgov_directory_facets_select
+    - field.field.node.localgov_directories_page.localgov_directory_files
+    - field.field.node.localgov_directories_page.localgov_directory_job_title
+    - field.field.node.localgov_directories_page.localgov_directory_name
+    - field.field.node.localgov_directories_page.localgov_directory_phone
+    - field.field.node.localgov_directories_page.localgov_directory_website
+    - node.type.localgov_directories_page
+  enforced:
+    module:
+      - localgov_directories
+  module:
+    - address
+    - link
+    - telephone
+    - text
+    - user
+id: node.localgov_directories_page.search_index
+targetEntityType: node
+bundle: localgov_directories_page
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  localgov_directory_address:
+    weight: 7
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+    region: content
+  localgov_directory_channels:
+    type: entity_reference_label
+    weight: 9
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  localgov_directory_email:
+    weight: 6
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: email_mailto
+    region: content
+  localgov_directory_files:
+    type: entity_reference_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    region: content
+  localgov_directory_job_title:
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_name:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_phone:
+    weight: 5
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  localgov_directory_search:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  localgov_directory_website:
+    weight: 8
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden:
+  links: true
+  localgov_directory_facets_select: true
+  search_api_excerpt: true

--- a/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_result.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_result.yml
@@ -1,0 +1,68 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_directory_address
+    - field.field.node.localgov_directories_page.localgov_directory_channels
+    - field.field.node.localgov_directories_page.localgov_directory_email
+    - field.field.node.localgov_directories_page.localgov_directory_facets_select
+    - field.field.node.localgov_directories_page.localgov_directory_files
+    - field.field.node.localgov_directories_page.localgov_directory_job_title
+    - field.field.node.localgov_directories_page.localgov_directory_name
+    - field.field.node.localgov_directories_page.localgov_directory_phone
+    - field.field.node.localgov_directories_page.localgov_directory_website
+    - node.type.localgov_directories_page
+  enforced:
+    module:
+      - localgov_directories
+  module:
+    - field_group
+    - text
+    - user
+third_party_settings:
+  field_group:
+    group_enquiries:
+      children:
+        - localgov_directory_name
+        - localgov_directory_job_title
+        - localgov_directory_phone
+        - localgov_directory_email
+        - localgov_directory_address
+        - localgov_directory_website
+      parent_name: ''
+      weight: 1
+      format_type: fieldset
+      region: hidden
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Enquiries
+id: node.localgov_directories_page.search_result
+targetEntityType: node
+bundle: localgov_directories_page
+mode: search_result
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 0
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+hidden:
+  links: true
+  localgov_directory_address: true
+  localgov_directory_channels: true
+  localgov_directory_email: true
+  localgov_directory_facets_select: true
+  localgov_directory_files: true
+  localgov_directory_job_title: true
+  localgov_directory_name: true
+  localgov_directory_phone: true
+  localgov_directory_search: true
+  localgov_directory_website: true
+  search_api_excerpt: true

--- a/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
@@ -72,7 +72,7 @@ third_party_settings:
         description: ''
         formatter: closed
         required_fields: true
-      label: Directory
+      label: Channels and facets
     group_enquiries:
       children:
         - localgov_directory_name

--- a/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
@@ -119,7 +119,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_index.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_index.yml
@@ -1,0 +1,122 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_directory_channels
+    - field.field.node.localgov_directories_venue.localgov_directory_email
+    - field.field.node.localgov_directories_venue.localgov_directory_facets_select
+    - field.field.node.localgov_directories_venue.localgov_directory_files
+    - field.field.node.localgov_directories_venue.localgov_directory_job_title
+    - field.field.node.localgov_directories_venue.localgov_directory_name
+    - field.field.node.localgov_directories_venue.localgov_directory_notes
+    - field.field.node.localgov_directories_venue.localgov_directory_opening_times
+    - field.field.node.localgov_directories_venue.localgov_directory_phone
+    - field.field.node.localgov_directories_venue.localgov_directory_website
+    - field.field.node.localgov_directories_venue.localgov_location
+    - node.type.localgov_directories_venue
+  module:
+    - link
+    - telephone
+    - text
+    - user
+id: node.localgov_directories_venue.search_index
+targetEntityType: node
+bundle: localgov_directories_venue
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  localgov_directory_channels:
+    type: entity_reference_label
+    weight: 10
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  localgov_directory_email:
+    weight: 8
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  localgov_directory_files:
+    weight: 1
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  localgov_directory_job_title:
+    weight: 6
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_name:
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_notes:
+    weight: 5
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  localgov_directory_opening_times:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  localgov_directory_phone:
+    weight: 7
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  localgov_directory_website:
+    weight: 9
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  localgov_location:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  links: true
+  localgov_directory_facets_select: true
+  localgov_directory_search: true
+  search_api_excerpt: true

--- a/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_result.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_result.yml
@@ -1,0 +1,152 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_directory_channels
+    - field.field.node.localgov_directories_venue.localgov_directory_email
+    - field.field.node.localgov_directories_venue.localgov_directory_facets_select
+    - field.field.node.localgov_directories_venue.localgov_directory_files
+    - field.field.node.localgov_directories_venue.localgov_directory_job_title
+    - field.field.node.localgov_directories_venue.localgov_directory_name
+    - field.field.node.localgov_directories_venue.localgov_directory_notes
+    - field.field.node.localgov_directories_venue.localgov_directory_opening_times
+    - field.field.node.localgov_directories_venue.localgov_directory_phone
+    - field.field.node.localgov_directories_venue.localgov_directory_website
+    - field.field.node.localgov_directories_venue.localgov_location
+    - node.type.localgov_directories_venue
+  module:
+    - field_group
+    - link
+    - telephone
+    - text
+    - user
+third_party_settings:
+  field_group:
+    group_enquiries:
+      children:
+        - localgov_directory_name
+        - localgov_directory_job_title
+        - localgov_directory_phone
+        - localgov_directory_email
+        - localgov_directory_website
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Enquiries
+    group_venue:
+      children:
+        - localgov_location
+        - localgov_directory_opening_times
+        - localgov_directory_notes
+      parent_name: ''
+      weight: 3
+      format_type: fieldset
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+      label: Venue
+id: node.localgov_directories_venue.search_result
+targetEntityType: node
+bundle: localgov_directories_venue
+mode: search_result
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  localgov_directory_email:
+    weight: 8
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  localgov_directory_files:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  localgov_directory_job_title:
+    weight: 6
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_name:
+    weight: 4
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  localgov_directory_notes:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  localgov_directory_opening_times:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  localgov_directory_phone:
+    weight: 7
+    label: inline
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  localgov_directory_search:
+    weight: -20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  localgov_directory_website:
+    weight: 9
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  localgov_location:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  links: true
+  localgov_directory_channels: true
+  localgov_directory_facets_select: true
+  search_api_excerpt: true


### PR DESCRIPTION
Changelog:

#81 @mattrfletcher  @stephen-cox Fixed Teaser view mode of the Directory channel content type
#82 @mattrfletcher  @stephen-cox Rename "Directory" tab "Channels and facets"
#102 @stephen-cox Fix GitHub CI after 2.0.0 release
#104 @Adnan-cds  @stephen-cox Directory map view: Removing the Views pager
#107 @danchamp @ekes  Set directory channel, page and venue summary form fields to always be visible
#120 @stephen-cox @finnlewis  Added search index and search result display modes