### PR TITLE
release-1.x to tag at 1.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Test LocalGov Drupal Directories
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '1.x'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '1.x'
 
 jobs:
 
@@ -12,52 +14,81 @@ jobs:
     name: Install LocalGov Drupal
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+
     steps:
+    
+      - name: Save git branch and git repo names to env if this is not a pull request
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          
+      - name: Save git branch and git repo names to env if this is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+  
+      - name: Set composer branch reference for version branches
+        if: endsWith(github.ref, '.x')
+        run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
+          
+      - name: Set composer branch reference for non-version branches
+        if: endsWith(github.ref, '.x') == false
+        run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
 
       - name: Cached workspace
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-version }}
 
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:
           repository: localgovdrupal/drupal-container
-          ref: master
+          ref: php${{ matrix.php-version }}
 
       - name: Create LocalGov Drupal project
-        run: composer create-project --stability dev localgovdrupal/localgov-project ./html
-
-      - name: Save git branch and git repo names to env if this is not a pull request
-        if: github.event_name != 'pull_request'
         run: |
-          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-
-      - name: Save git branch and git repo names to env if this is a pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
-
+          composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
+          composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
+          composer install
+          
       - name: Setup package source and authentication for the test target
         run: |
           composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
 
   phpcs:
     name: Coding standards checks
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -65,10 +96,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -78,11 +108,18 @@ jobs:
         run: |
           cd html
           ./bin/phpcs -p
-
   phpstan:
     name: Deprecated code checks
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -90,10 +127,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -103,11 +139,18 @@ jobs:
         run: |
           cd html
           ./bin/phpstan analyse -c ./phpstan.neon ./web/profiles/contrib/localgov/ ./web/modules/contrib/localgov_*
-
   phpunit:
     name: PHPUnit tests
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -121,10 +164,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Start Docker environment
         run: docker-compose -f docker-compose.yml up -d
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
-        "localgovdrupal/localgov_core": "^1.0@alpha",
-        "localgovdrupal/localgov_geo": "^1.0@alpha"
+        "localgovdrupal/localgov_core": "^1.0",
+        "localgovdrupal/localgov_geo": "^1.0"
     },
     "require-dev": {
-        "localgovdrupal/localgov_services": "1.0.0-alpha1"
+        "localgovdrupal/localgov_services": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
         "localgovdrupal/localgov_core": "^1.0",
-        "localgovdrupal/localgov_geo": "^1.0"
+        "localgovdrupal/localgov_geo": "~1.0.0"
     },
     "require-dev": {
         "localgovdrupal/localgov_services": "^1.0"

--- a/config/install/core.entity_form_display.node.localgov_directory.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_directory.default.yml
@@ -21,7 +21,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_form_display.node.localgov_directories_page.default.yml
@@ -103,7 +103,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_page/tests/src/Functional/DirectoryPageTest.php
+++ b/modules/localgov_directories_page/tests/src/Functional/DirectoryPageTest.php
@@ -42,7 +42,7 @@ class DirectoryPageTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_directories_page',
     'field_ui',
   ];
@@ -50,7 +50,7 @@ class DirectoryPageTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser([

--- a/modules/localgov_directories_page/tests/src/Functional/PathIntegrationTest.php
+++ b/modules/localgov_directories_page/tests/src/Functional/PathIntegrationTest.php
@@ -43,7 +43,7 @@ class PathIntegrationTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_directories',
     'localgov_directories_page',
   ];
@@ -51,10 +51,13 @@ class PathIntegrationTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
-    $this->adminUser = $this->drupalCreateUser(['bypass node access', 'administer nodes']);
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+    ]);
     $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
   }
 
@@ -79,7 +82,7 @@ class PathIntegrationTest extends BrowserTestBase {
     $form->checkField('edit-status-value');
     $form->pressButton('edit-submit');
 
-    $this->assertText('Page 1');
+    $this->assertSession()->pageTextContains('Page 1');
     $trail = ['' => 'Home'];
     $trail += ['directory-1' => 'Directory 1'];
     $this->assertBreadcrumb(NULL, $trail);

--- a/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_form_display.node.localgov_directories_venue.default.yml
@@ -119,7 +119,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/modules/localgov_directories_venue/tests/Functional/DirectoryVenueTest.php
+++ b/modules/localgov_directories_venue/tests/Functional/DirectoryVenueTest.php
@@ -42,7 +42,7 @@ class DirectoryVenueTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_directories_venue',
     'field_ui',
   ];
@@ -50,7 +50,7 @@ class DirectoryVenueTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser([

--- a/src/Form/LocalgovDirectoriesFacetsTypeForm.php
+++ b/src/Form/LocalgovDirectoriesFacetsTypeForm.php
@@ -42,7 +42,10 @@ class LocalgovDirectoriesFacetsTypeForm extends BundleEntityFormBase {
       '#default_value' => $entity_type->id(),
       '#maxlength' => EntityTypeInterface::BUNDLE_MAX_LENGTH,
       '#machine_name' => [
-        'exists' => ['Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType', 'load'],
+        'exists' => [
+          'Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType',
+          'load',
+        ],
         'source' => ['label'],
       ],
       '#description' => $this->t('A unique machine-readable name for this directory facets type. It must only contain lowercase letters, numbers, and underscores.'),

--- a/src/LocalgovDirectoriesFacetsAccessControlHandler.php
+++ b/src/LocalgovDirectoriesFacetsAccessControlHandler.php
@@ -22,10 +22,18 @@ class LocalgovDirectoriesFacetsAccessControlHandler extends EntityAccessControlH
         return AccessResult::allowedIfHasPermission($account, 'view directory facets');
 
       case 'update':
-        return AccessResult::allowedIfHasPermissions($account, ['edit directory facets', 'administer directory facets'], 'OR');
+        return AccessResult::allowedIfHasPermissions(
+          $account,
+          ['edit directory facets', 'administer directory facets'],
+          'OR'
+        );
 
       case 'delete':
-        return AccessResult::allowedIfHasPermissions($account, ['delete directory facets', 'administer directory facets'], 'OR');
+        return AccessResult::allowedIfHasPermissions(
+          $account,
+          ['delete directory facets', 'administer directory facets'],
+          'OR'
+        );
 
       default:
         // No opinion.
@@ -38,7 +46,11 @@ class LocalgovDirectoriesFacetsAccessControlHandler extends EntityAccessControlH
    * {@inheritdoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    return AccessResult::allowedIfHasPermissions($account, ['create directory facets', 'administer directory facets'], 'OR');
+    return AccessResult::allowedIfHasPermissions(
+      $account,
+      ['create directory facets', 'administer directory facets'],
+      'OR'
+    );
   }
 
 }

--- a/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
+++ b/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
@@ -33,7 +33,7 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_directories',
     'field_ui',
     'block',
@@ -48,7 +48,7 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->drupalPlaceBlock('system_breadcrumb_block');
@@ -123,8 +123,10 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
       ]
     );
     // Set the widget.
-    $this->drupalPostForm('/admin/structure/types/manage/entry_1/form-display', ['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
-    $this->drupalPostForm('/admin/structure/types/manage/entry_2/form-display', ['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
+    $this->drupalGet('/admin/structure/types/manage/entry_1/form-display');
+    $this->submitForm(['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
+    $this->drupalGet('/admin/structure/types/manage/entry_2/form-display');
+    $this->submitForm(['fields[field_channels][type]' => 'localgov_directories_channel_selector'], 'edit-submit');
 
     // Check the correct channels are on the different entry forms.
     $this->drupalGet('/node/add/entry_1');
@@ -136,19 +138,14 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
     $assert_session->pageTextContains('Directory 2');
 
     // Set a default.
-    $this->drupalPostForm(
-      '/admin/structure/types/manage/entry_1/fields/node.entry_1.field_channels',
-      [
-        'default_value_input[field_channels][primary]' => $this->directories[2]->id(),
-      ],
+    $this->drupalGet('/admin/structure/types/manage/entry_1/fields/node.entry_1.field_channels');
+    $this->submitForm(
+      ['default_value_input[field_channels][primary]' => $this->directories[2]->id()],
       'edit-submit'
     );
-    $this->drupalGet('/admin/structure/types/manage/entry_1/fields/node.entry_1.field_channels');
-    $this->drupalPostForm(
-      '/admin/structure/types/manage/entry_2/fields/node.entry_2.field_channels',
-      [
-        'default_value_input[field_channels][primary]' => $this->directories[2]->id(),
-      ],
+    $this->drupalGet('/admin/structure/types/manage/entry_2/fields/node.entry_2.field_channels');
+    $this->submitForm(
+      ['default_value_input[field_channels][primary]' => $this->directories[2]->id()],
       'edit-submit'
     );
 
@@ -157,10 +154,10 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
     $page = $this->getSession()->getPage();
     $assert_session = $this->assertSession();
     $radio = $page->findField('field_channels[primary]');
-    $this->assertEqual($radio->getValue(), $this->directories[2]->id());
+    $this->assertEquals($radio->getValue(), $this->directories[2]->id());
     $this->drupalGet('/node/add/entry_2');
     $radio = $page->findField('field_channels[primary]');
-    $this->assertEqual($radio->getValue(), $this->directories[2]->id());
+    $this->assertEquals($radio->getValue(), $this->directories[2]->id());
     $assert_session->fieldNotExists('edit-field-channels-secondary-1');
   }
 

--- a/tests/src/Functional/ServicesIntegrationTest.php
+++ b/tests/src/Functional/ServicesIntegrationTest.php
@@ -45,7 +45,7 @@ class ServicesIntegrationTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_core',
     'localgov_services_landing',
     'localgov_services_sublanding',
@@ -56,17 +56,26 @@ class ServicesIntegrationTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
-    $this->adminUser = $this->drupalCreateUser(['bypass node access', 'administer nodes']);
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+    ]);
     $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
 
     // To submit a directory we need a facet.
     $type_id = $this->randomMachineName();
-    $type = LocalgovDirectoriesFacetsType::create(['id' => $type_id, 'label' => $type_id]);
+    $type = LocalgovDirectoriesFacetsType::create([
+      'id' => $type_id,
+      'label' => $type_id,
+    ]);
     $type->save();
-    $facet = LocalgovDirectoriesFacets::create(['bundle' => $type_id, 'title' => $this->randomMachineName()]);
+    $facet = LocalgovDirectoriesFacets::create([
+      'bundle' => $type_id,
+      'title' => $this->randomMachineName(),
+    ]);
     $facet->save();
   }
 

--- a/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
+++ b/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
@@ -35,7 +35,7 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_directories',
     'field_ui',
   ];
@@ -49,26 +49,38 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Three bundles of five facets.
     for ($i = 0; $i < 3; $i++) {
       $type_id = $this->randomMachineName();
-      $type = LocalgovDirectoriesFacetsType::create(['id' => $type_id, 'label' => $type_id]);
+      $type = LocalgovDirectoriesFacetsType::create([
+        'id' => $type_id,
+        'label' => $type_id,
+      ]);
       $type->save();
       $this->facet_types[$type_id] = $type;
       for ($j = 0; $j < 5; $j++) {
-        $facet = LocalgovDirectoriesFacets::create(['bundle' => $type_id, 'title' => $this->randomMachineName()]);
+        $facet = LocalgovDirectoriesFacets::create([
+          'bundle' => $type_id,
+          'title' => $this->randomMachineName(),
+        ]);
         $facet->save();
         $this->facets[$type_id][$facet->id()] = $facet;
       }
     }
     // Another bundle with just one facet.
-    $type = LocalgovDirectoriesFacetsType::create(['id' => 'facetbundleonefacet', 'label' => 'facetbundleonefacet']);
+    $type = LocalgovDirectoriesFacetsType::create([
+      'id' => 'facetbundleonefacet',
+      'label' => 'facetbundleonefacet',
+    ]);
     $type->save();
     $this->facet_types['facetbundleonefacet'] = $type;
-    $facet = LocalgovDirectoriesFacets::create(['bundle' => 'facetbundleonefacet', 'title' => $this->randomMachineName()]);
+    $facet = LocalgovDirectoriesFacets::create([
+      'bundle' => 'facetbundleonefacet',
+      'title' => $this->randomMachineName(),
+    ]);
     $facet->save();
     $this->facets['facetbundleonefacet'][$facet->id()] = $facet;
 

--- a/tests/src/Kernel/EntityReferenceChannelsSelectionTest.php
+++ b/tests/src/Kernel/EntityReferenceChannelsSelectionTest.php
@@ -59,7 +59,7 @@ class EntityReferenceChannelsSelectionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('node');

--- a/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
+++ b/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
@@ -58,7 +58,7 @@ class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('node');
@@ -82,7 +82,10 @@ class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
     // Two content types implementing the magically named
     // 'localgov_directory_channels' field.
     $page_type = strtolower($this->randomMachineName());
-    $entry_types[$page_type] = NodeType::create(['type' => $page_type, 'name' => $this->randomMachineName()]);
+    $entry_types[$page_type] = NodeType::create([
+      'type' => $page_type,
+      'name' => $this->randomMachineName(),
+    ]);
     $entry_types[$page_type]->save();
     $handler_settings = [
       'sort' => [
@@ -93,7 +96,10 @@ class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
     $this->createEntityReferenceField('node', $page_type, 'localgov_directory_channels', $this->randomString(), 'node', 'localgov_directories_channels_selection', $handler_settings);
 
     $other_type = strtolower($this->randomMachineName());
-    $entry_types[$other_type] = NodeType::create(['type' => $other_type, 'name' => $this->randomMachineName()]);
+    $entry_types[$other_type] = NodeType::create([
+      'type' => $other_type,
+      'name' => $this->randomMachineName(),
+    ]);
     $entry_types[$other_type]->save();
     $handler_settings = [
       'sort' => [
@@ -112,19 +118,25 @@ class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
     }
 
     // Check a non-directory entry is not returned.
-    $non_directory = NodeType::create(['type' => $this->randomMachineName(), 'name' => $this->randomMachineName()]);
+    $non_directory = NodeType::create([
+      'type' => $this->randomMachineName(),
+      'name' => $this->randomMachineName(),
+    ]);
     $non_directory->save();
     foreach ($selection['node_type'] as $machine_name => $label) {
       $this->assertSame($label, $entry_types[$machine_name]->label());
     }
 
     // Check count.
-    $this->assert($this->selectionHandler->countReferenceableEntities(), 2);
+    $this->assertEquals(1, $this->selectionHandler->countReferenceableEntities());
 
     // Check validate.
     $this->assertGreaterThan(0, count($this->selectionHandler->validateReferenceableEntities([$other_type])));
-    $this->assertGreaterThan(0, count($this->selectionHandler->validateReferenceableEntities([$page_type, $other_type])));
-    $this->assertEqual(0, count($this->selectionHandler->validateReferenceableEntities([$non_directory->id()])));
+    $this->assertGreaterThan(0, count($this->selectionHandler->validateReferenceableEntities([
+      $page_type,
+      $other_type,
+    ])));
+    $this->assertEquals(0, count($this->selectionHandler->validateReferenceableEntities([$non_directory->id()])));
   }
 
 }

--- a/tests/src/Kernel/FacetIndexFieldSetupTest.php
+++ b/tests/src/Kernel/FacetIndexFieldSetupTest.php
@@ -45,7 +45,7 @@ class FacetIndexFieldSetupTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('node');

--- a/tests/src/Unit/FacetPreprocessTest.php
+++ b/tests/src/Unit/FacetPreprocessTest.php
@@ -56,7 +56,7 @@ class FacetPreprocessTest extends UnitTestCase {
 
     $sorted_facet_types = array_keys($facet_tpl_variables['items']);
     $expected_sorted_facet_types = ['jar', 'qux', 'bar', 'baz', 'foo'];
-    $this->assertArrayEquals($expected_sorted_facet_types, $sorted_facet_types);
+    $this->assertSame($expected_sorted_facet_types, $sorted_facet_types);
   }
 
   /**
@@ -66,7 +66,7 @@ class FacetPreprocessTest extends UnitTestCase {
    *
    * @see DirectoryExtraFieldDisplay::__construct()
    */
-  public function setup() {
+  public function setup(): void {
 
     // Facet items.
     $facet_zero = $this->createMock(LocalgovDirectoriesFacets::class);


### PR DESCRIPTION
Release to tag at 1.0.1

Primary motivation is to pin dependency on localgov_geo to 1.0.x rather than allow it to jump to 1.1.0.

Also includes 

@ekes Update composer dependencies to non-alpha localgov modules. c18c8f3
@stephen-cox Drupal 9 coding standards and deprecations fixes (#79) (#80) 4d6f6ce
@stephen-cox Updated Github CI to run 1.x branch against Drupal 8 (#84) fd64a92
@danchamp Set directory channel, page and venue summary form fields to always b… 8e7f7c0
@finnlewis Fix dependencies for the 1.x branch to keep localgov_geo at 1.0.x rat… a419ade
