### PR TITLE
Removed 'Block %block-id is missing. Cannot update its visibility settings' error message

### DIFF
--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -392,10 +392,6 @@ function localgov_directories_add_block_to_content_type_sidebar(string $block_id
 
   $block_config = Block::load($block_id);
   if (empty($block_config)) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Block %block-id is missing.  Cannot update its visibility settings.', [
-      '%block-id' => $block_id,
-    ]);
-
     return FALSE;
   }
 


### PR DESCRIPTION
This error message is being thrown when directories are being enabled in the Microsites distribution and doesn't convey any useful information, so let's remove it.

The function that produces the error message attempts to update the visibility settings of the `localgov_directories_channel_search_block` (which is the only time this function is used). The aim is to display the search block on Directory Pages, but we don't want this displaying on these pages, only Channels, so we don't want to fix the error.

Fixes #194