### PR TITLE
2.3.1 release

### DIFF
--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -252,3 +252,16 @@ function localgov_directories_update_8007() {
   $config->set('module', $modules);
   $config->save();
 }
+
+/**
+ * Add schema version for Directories Search API DB module.
+ */
+function localgov_directories_update_8008() {
+  $config = \Drupal::config('core.extension');
+  $modules = $config->get('module');
+  if (isset($modules['localgov_directories_db']) &&
+    !\Drupal::keyValue('system.schema')->has('localgov_directories_db')
+  ) {
+    \Drupal::keyValue('system.schema')->set('localgov_directories_db', 8000);
+  }
+}


### PR DESCRIPTION
* Fix for #213

* Fix if both 8007 and 8008 are run at the same time.

Running 8007 and then 8008 seperately works with the module check, but
not when both are run consecutively in the same call. Reseting module
list didn't help.