### PR TITLE
Add search result highlight to search result highlight display

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
@@ -15,20 +15,19 @@ targetEntityType: node
 bundle: localgov_directory
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
+  content_moderation_control: true
   links: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_facets_enable: true
   localgov_directory_map: true
   localgov_directory_view: true
+  localgov_directory_view_with_search: true
   localgov_services_parent: true
-  search_api_excerpt: true

--- a/modules/localgov_directories_org/config/install/core.entity_view_display.node.localgov_directories_org.search_result.yml
+++ b/modules/localgov_directories_org/config/install/core.entity_view_display.node.localgov_directories_org.search_result.yml
@@ -1,0 +1,70 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_directories_org.body
+    - field.field.node.localgov_directories_org.localgov_directory_channels
+    - field.field.node.localgov_directories_org.localgov_directory_email
+    - field.field.node.localgov_directories_org.localgov_directory_facets_select
+    - field.field.node.localgov_directories_org.localgov_directory_files
+    - field.field.node.localgov_directories_org.localgov_directory_notes
+    - field.field.node.localgov_directories_org.localgov_directory_phone
+    - field.field.node.localgov_directories_org.localgov_directory_website
+    - field.field.node.localgov_directories_org.localgov_location
+    - node.type.localgov_directories_org
+  module:
+    - field_group
+    - user
+third_party_settings:
+  field_group:
+    group_enquiries:
+      children:
+        - localgov_directory_email
+        - localgov_directory_phone
+        - localgov_directory_website
+      label: Enquiries
+      parent_name: ''
+      region: hidden
+      weight: 10
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+    group_organisation:
+      children:
+        - localgov_directory_notes
+        - localgov_location
+      label: Venue
+      parent_name: ''
+      region: hidden
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+id: node.localgov_directories_org.search_result
+targetEntityType: node
+bundle: localgov_directories_org
+mode: search_result
+content:
+  search_api_excerpt:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  content_moderation_control: true
+  links: true
+  localgov_directory_channels: true
+  localgov_directory_email: true
+  localgov_directory_facets_select: true
+  localgov_directory_files: true
+  localgov_directory_notes: true
+  localgov_directory_phone: true
+  localgov_directory_search: true
+  localgov_directory_website: true
+  localgov_location: true

--- a/modules/localgov_directories_org/tests/Functional/LocalgovIntegrationTest.php
+++ b/modules/localgov_directories_org/tests/Functional/LocalgovIntegrationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories_org\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests pages working together with LocalGov search.
+ *
+ * @group localgov_directories
+ */
+class LocalgovIntegrationTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use CronRunTrait;
+
+  /**
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
+   */
+  protected $profile = 'testing';
+
+  /**
+   * Use stark as tests are not dependent on core markup.
+   *
+   * @var string
+   *
+   * @see https://www.drupal.org/node/3083055
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_directories',
+    'localgov_directories_org',
+    'localgov_search',
+    'localgov_search_db',
+  ];
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    // Directory.
+    $directory = $this->createNode([
+      'title' => 'Directory 1',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->createNode([
+      'title' => 'Directory org 1',
+      'type' => 'localgov_directories_org',
+      'localgov_directory_channels' => ['target_id' => $directory->id()],
+      'body' => $body,
+    ]);
+    $this->cronRun();
+
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Directory org 1');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+  }
+
+}

--- a/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_result.yml
+++ b/modules/localgov_directories_page/config/install/core.entity_view_display.node.localgov_directories_page.search_result.yml
@@ -15,46 +15,45 @@ dependencies:
     - field.field.node.localgov_directories_page.localgov_directory_title_sort
     - field.field.node.localgov_directories_page.localgov_directory_website
     - node.type.localgov_directories_page
-  enforced:
-    module:
-      - localgov_directories
   module:
     - field_group
     - text
     - user
+  enforced:
+    module:
+      - localgov_directories
 third_party_settings:
   field_group:
     group_enquiries:
       children:
-        - localgov_directory_name
-        - localgov_directory_job_title
-        - localgov_directory_phone
-        - localgov_directory_email
         - localgov_directory_address
+        - localgov_directory_email
+        - localgov_directory_job_title
+        - localgov_directory_name
+        - localgov_directory_phone
         - localgov_directory_website
-      parent_name: ''
-      weight: 1
-      format_type: fieldset
-      region: hidden
-      format_settings:
-        id: ''
-        classes: ''
-        description: ''
       label: Enquiries
+      parent_name: ''
+      region: hidden
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
 id: node.localgov_directories_page.search_result
 targetEntityType: node
 bundle: localgov_directories_page
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
+  content_moderation_control: true
   links: true
   localgov_directory_address: true
   localgov_directory_channels: true
@@ -67,4 +66,3 @@ hidden:
   localgov_directory_search: true
   localgov_directory_title_sort: true
   localgov_directory_website: true
-  search_api_excerpt: true

--- a/modules/localgov_directories_promo_page/config/install/core.entity_view_display.node.localgov_directory_promo_page.search_result.yml
+++ b/modules/localgov_directories_promo_page/config/install/core.entity_view_display.node.localgov_directory_promo_page.search_result.yml
@@ -1,0 +1,110 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_directory_promo_page.body
+    - field.field.node.localgov_directory_promo_page.localgov_directory_address
+    - field.field.node.localgov_directory_promo_page.localgov_directory_banner
+    - field.field.node.localgov_directory_promo_page.localgov_directory_channels
+    - field.field.node.localgov_directory_promo_page.localgov_directory_email
+    - field.field.node.localgov_directory_promo_page.localgov_directory_facets_select
+    - field.field.node.localgov_directory_promo_page.localgov_directory_files
+    - field.field.node.localgov_directory_promo_page.localgov_directory_job_title
+    - field.field.node.localgov_directory_promo_page.localgov_directory_name
+    - field.field.node.localgov_directory_promo_page.localgov_directory_phone
+    - field.field.node.localgov_directory_promo_page.localgov_directory_standfirst
+    - field.field.node.localgov_directory_promo_page.localgov_directory_title_sort
+    - field.field.node.localgov_directory_promo_page.localgov_directory_website
+    - field.field.node.localgov_directory_promo_page.localgov_paragraph_content
+    - node.type.localgov_directory_promo_page
+  module:
+    - field_group
+    - user
+third_party_settings:
+  field_group:
+    group_banner:
+      children:
+        - localgov_directory_banner
+      label: Banner
+      parent_name: ''
+      region: hidden
+      weight: 2
+      format_type: html_element
+      format_settings:
+        classes: full__banner
+        show_empty_fields: false
+        id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_page_top:
+      children:
+        - localgov_directory_standfirst
+        - localgov_directory_facets_select
+      label: 'Page Top'
+      parent_name: ''
+      region: hidden
+      weight: 3
+      format_type: html_element
+      format_settings:
+        classes: full__page-top
+        show_empty_fields: false
+        id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_enquiries:
+      children:
+        - localgov_directory_name
+        - localgov_directory_job_title
+        - localgov_directory_phone
+        - localgov_directory_email
+        - localgov_directory_website
+        - localgov_directory_address
+      label: Enquiries
+      parent_name: ''
+      region: hidden
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+id: node.localgov_directory_promo_page.search_result
+targetEntityType: node
+bundle: localgov_directory_promo_page
+mode: search_result
+content:
+  search_api_excerpt:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  content_moderation_control: true
+  links: true
+  localgov_directory_address: true
+  localgov_directory_banner: true
+  localgov_directory_channels: true
+  localgov_directory_email: true
+  localgov_directory_facets_select: true
+  localgov_directory_files: true
+  localgov_directory_job_title: true
+  localgov_directory_name: true
+  localgov_directory_phone: true
+  localgov_directory_search: true
+  localgov_directory_standfirst: true
+  localgov_directory_title_sort: true
+  localgov_directory_website: true
+  localgov_paragraph_content: true

--- a/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
@@ -15,7 +15,6 @@ class DirectoryPromoPageTest extends BrowserTestBase {
 
   use NodeCreationTrait;
   use AssertBreadcrumbTrait;
-  protected $strictConfigSchema = FALSE;
 
   /**
    * Test breadcrumbs in the Standard profile.

--- a/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
@@ -15,6 +15,7 @@ class DirectoryPromoPageTest extends BrowserTestBase {
 
   use NodeCreationTrait;
   use AssertBreadcrumbTrait;
+  protected $strictConfigSchema = FALSE;
 
   /**
    * Test breadcrumbs in the Standard profile.

--- a/modules/localgov_directories_promo_page/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Functional/LocalgovIntegrationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories_promo_page\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests pages working together with LocalGov search.
+ *
+ * @group localgov_directories
+ */
+class LocalgovIntegrationTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use CronRunTrait;
+
+  /**
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
+   */
+  protected $profile = 'testing';
+
+  /**
+   * Use stark as tests are not dependent on core markup.
+   *
+   * @var string
+   *
+   * @see https://www.drupal.org/node/3083055
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_directories',
+    'localgov_directories_promo_page',
+    'localgov_search',
+    'localgov_search_db',
+  ];
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    // Directory.
+    $directory = $this->createNode([
+      'title' => 'Directory 1',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->createNode([
+      'title' => 'Directory page 1',
+      'type' => 'localgov_directory_promo_page',
+      'localgov_directory_channels' => ['target_id' => $directory->id()],
+      'body' => $body,
+    ]);
+    $this->cronRun();
+
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Directory page 1');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+  }
+
+}

--- a/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_result.yml
+++ b/modules/localgov_directories_venue/config/install/core.entity_view_display.node.localgov_directories_venue.search_result.yml
@@ -32,123 +32,53 @@ third_party_settings:
         - localgov_directory_phone
         - localgov_directory_email
         - localgov_directory_website
-      parent_name: ''
-      weight: 4
-      format_type: fieldset
-      region: content
-      format_settings:
-        id: ''
-        classes: ''
-        description: ''
       label: Enquiries
+      parent_name: ''
+      region: hidden
+      weight: 6
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
     group_venue:
       children:
         - localgov_location
         - localgov_directory_opening_times
         - localgov_directory_notes
-      parent_name: ''
-      weight: 3
-      format_type: fieldset
-      region: content
-      format_settings:
-        id: ''
-        classes: ''
-        description: ''
       label: Venue
+      parent_name: ''
+      region: hidden
+      weight: 5
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
 id: node.localgov_directories_venue.search_result
 targetEntityType: node
 bundle: localgov_directories_venue
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_default
+  search_api_excerpt:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-  localgov_directory_email:
-    weight: 8
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
-    type: basic_string
-    region: content
-  localgov_directory_files:
-    weight: 1
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  localgov_directory_job_title:
-    weight: 6
-    label: inline
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  localgov_directory_name:
-    weight: 4
-    label: inline
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  localgov_directory_notes:
-    weight: 4
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: content
-  localgov_directory_opening_times:
-    weight: 3
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: content
-  localgov_directory_phone:
-    weight: 7
-    label: inline
-    settings:
-      title: ''
-    third_party_settings: {  }
-    type: telephone_link
-    region: content
-  localgov_directory_search:
-    weight: -20
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  localgov_directory_website:
-    weight: 9
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
-  localgov_location:
-    weight: 2
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    type: entity_reference_entity_view
     region: content
 hidden:
+  body: true
+  content_moderation_control: true
   links: true
   localgov_directory_channels: true
+  localgov_directory_email: true
   localgov_directory_facets_select: true
+  localgov_directory_files: true
+  localgov_directory_job_title: true
+  localgov_directory_name: true
+  localgov_directory_notes: true
+  localgov_directory_opening_times: true
+  localgov_directory_phone: true
+  localgov_directory_search: true
   localgov_directory_title_sort: true
-  search_api_excerpt: true
+  localgov_directory_website: true
+  localgov_location: true

--- a/modules/localgov_directories_venue/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/modules/localgov_directories_venue/tests/src/Functional/LocalgovIntegrationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories_venue\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests pages working together with LocalGov search.
+ *
+ * @group localgov_directories
+ */
+class LocalgovIntegrationTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use CronRunTrait;
+
+  /**
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
+   */
+  protected $profile = 'testing';
+
+  /**
+   * Use stark as tests are not dependent on core markup.
+   *
+   * @var string
+   *
+   * @see https://www.drupal.org/node/3083055
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_directories',
+    'localgov_directories_venue',
+    'localgov_search',
+    'localgov_search_db',
+  ];
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    // Directory.
+    $directory = $this->createNode([
+      'title' => 'Directory 1',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $page = $this->createNode([
+      'title' => 'Directory page 1',
+      'type' => 'localgov_directories_venue',
+      'localgov_directory_channels' => ['target_id' => $directory->id()],
+      'body' => $body,
+    ]);
+    $this->cronRun();
+
+    $this->drupalGet($page->toUrl()->toString());
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Directory page 1');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+  }
+
+}

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -130,7 +130,7 @@ class LocalgovIntegrationTest extends BrowserTestBase {
       'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
     ];
     // Directory.
-    $directory = $this->createNode([
+    $this->createNode([
       'title' => 'Directory 1',
       'type' => 'localgov_directory',
       'status' => NodeInterface::PUBLISHED,


### PR DESCRIPTION
Fix #215

This is for sitewide search, not the directory search.

Usual cavet about using search_api as dependency applies.
(If not using search_api, the search result display will be blank)
