### PR TITLE
Fix search index fields, and block, on install.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,16 @@
     "suggest": {
         "localgovdrupal/localgov_openreferral": "Enables Open Referral output of Directories",
         "localgovdrupal/localgov_paragraphs": "For Directory Promo Page content type in Directories"
+    },
+    "extra": {
+        "composer-exit-on-patch-failure": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        },
+        "patches": {
+            "drupal/facets": {
+                "Don't render facet block if backend isn't available: https://www.drupal.org/project/facets/issues/3311856": "https://git.drupalcode.org/issue/facets-3311856/-/commit/765d5ef4228906c7f201e116763f3018a7867c96.patch"
+            }
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,6 @@
         "localgovdrupal/localgov_paragraphs": "For Directory Promo Page content type in Directories"
     },
     "extra": {
-        "composer-exit-on-patch-failure": true,
-        "patchLevel": {
-            "drupal/core": "-p2"
-        },
         "patches": {
             "drupal/facets": {
                 "Don't render facet block if backend isn't available: https://www.drupal.org/project/facets/issues/3311856": "https://git.drupalcode.org/issue/facets-3311856/-/commit/765d5ef4228906c7f201e116763f3018a7867c96.patch"

--- a/config/conditional/facets.facet.localgov_directories_facets.yml
+++ b/config/conditional/facets.facet.localgov_directories_facets.yml
@@ -36,7 +36,7 @@ processor_configs:
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: 40
+      build: 40
     settings:
       sort: ASC
   translate_entity:
@@ -53,9 +53,7 @@ processor_configs:
   weight_property_order:
     processor_id: weight_property_order
     weights:
-      sort: -5
-    settings:
-      sort: ASC
+      build: -5
 empty_behavior:
   behavior: none
 show_title: false

--- a/config/install/search_api.index.localgov_directories_index_default.yml
+++ b/config/install/search_api.index.localgov_directories_index_default.yml
@@ -14,22 +14,6 @@ name: Directories
 description: ''
 read_only: false
 field_settings:
-  localgov_directory_channels:
-    label: 'Directory channels'
-    datasource_id: 'entity:node'
-    property_path: localgov_directory_channels
-    type: integer
-    dependencies:
-      config:
-        - field.storage.node.localgov_directory_channels
-  localgov_directory_title_sort:
-    label: 'Title (sort)'
-    datasource_id: 'entity:node'
-    property_path: localgov_directory_title_sort
-    type: string
-    dependencies:
-      config:
-        - field.storage.node.localgov_directory_title_sort
   rendered_item:
     label: 'Rendered HTML output'
     property_path: rendered_item

--- a/config/install/search_api.index.localgov_directories_index_default.yml
+++ b/config/install/search_api.index.localgov_directories_index_default.yml
@@ -29,8 +29,7 @@ datasource_settings:
   'entity:node':
     bundles:
       default: false
-      selected:
-        - localgov_directories_page
+      selected: {  }
     languages:
       default: true
       selected: {  }

--- a/localgov_directories.info.yml
+++ b/localgov_directories.info.yml
@@ -14,7 +14,6 @@ dependencies:
   - drupal:views
   - pathauto:pathauto
   - search_api:search_api
-  - search_api:search_api_db
   - facets:facets
   - localgov_core:localgov_core
   - localgov_core:localgov_media

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -33,7 +33,7 @@ function localgov_directories_requirements($phase) {
   if ($phase != 'runtime') {
     return [];
   }
-  // Raise a warning if there is not backend selected, or no
+  // Raise a warning if there is no backend selected, or no
   // content types.
   $requirements = [];
   $index = \Drupal::entityTypeManager()->getStorage('search_api_index')->load(Constants::DEFAULT_INDEX);

--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -9,8 +9,10 @@ use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\localgov_directories\Constants;
 use Drupal\node\Entity\NodeType;
 use Drupal\search_api\Entity\Index;
+use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Item\Field;
 use Drupal\views\Entity\View;
 
@@ -22,6 +24,40 @@ function localgov_directories_install() {
   if ($services) {
     localgov_directories_optional_fields_settings($services);
   }
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function localgov_directories_requirements($phase) {
+  if ($phase != 'runtime') {
+    return [];
+  }
+  // Raise a warning if there is not backend selected, or no
+  // content types.
+  $requirements = [];
+  $index = \Drupal::entityTypeManager()->getStorage('search_api_index')->load(Constants::DEFAULT_INDEX);
+  if ($index instanceof IndexInterface) {
+    if ($index->getServerId() === NULL) {
+      $requirements['server'] = [
+        'title' => t('LocalGov Directories: Server'),
+        'description' => t('Directories requires a server. For the defaut Database server enable the <em>LocalGov Directories Database</em> module.'),
+        'severity' => REQUIREMENT_WARNING,
+      ];
+    }
+    if ($datasource = $index->getDatasource('entity:node')) {
+      $configuration = $datasource->getConfiguration();
+      if (empty($configuration['bundles']['selected'])) {
+        $requirements['content_type'] = [
+          'title' => t('LocalGov Directories: Content type'),
+          'description' => t('Directories requires at least one content. For a simple page enable the <em>LocalGov Directories Page</em> module.'),
+          'severity' => REQUIREMENT_WARNING,
+        ];
+      }
+    }
+  }
+
+  return $requirements;
 }
 
 /**

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -35,6 +35,10 @@ function localgov_directories_theme() {
       'base hook' => 'facets_item_list',
       'template'  => 'facets-item-list--links--localgov-directories-facets',
     ],
+    'facets_item_list__dropdown__localgov_directories_facets' => [
+      'base hook' => 'facets_item_list',
+      'template'  => 'facets-item-list--dropdown--localgov-directories-facets',
+    ],
   ];
 }
 

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -14,6 +14,7 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Element;
 use Drupal\facets\Entity\Facet;
 use Drupal\field\FieldConfigInterface;
+use Drupal\localgov_directories\ConfigurationHelper;
 use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
 use Drupal\localgov_roles\RolesHelper;
 use Drupal\node\NodeInterface;
@@ -40,10 +41,6 @@ function localgov_directories_theme() {
     'facets_item_list__checkbox__localgov_directories_facets' => [
       'base hook' => 'facets_item_list',
       'template'  => 'facets-item-list--links--localgov-directories-facets',
-    ],
-    'facets_item_list__dropdown__localgov_directories_facets' => [
-      'base hook' => 'facets_item_list',
-      'template'  => 'facets-item-list--dropdown--localgov-directories-facets',
     ],
   ];
 }
@@ -151,86 +148,14 @@ function localgov_directories_optional_fields_settings($services) {
  *   entry content type.
  */
 function localgov_directories_field_config_insert(FieldConfigInterface $field) {
-  // If a content type can be added to a directory channel add it to the index.
-  //
-  // While search_api could index more entity types to extend will require
-  // updating fields, and aggregating the facet ones. Only 'node' updated here
-  // for now.
-  if (
-    $field->getName() == 'localgov_directory_channels' &&
-    $field->getTargetEntityTypeId() == 'node' &&
-    ($index = Index::load('localgov_directories_index_default'))
-  ) {
-    $entity_type_id = 'node';
-    $entity_bundle = $field->getTargetBundle();
-
-    $index = Index::load('localgov_directories_index_default');
-    $datasource = $index->getDatasource('entity:' . $entity_type_id);
-    if (!$datasource) {
-      // If the content:node datasource has been lost so have the fields most
-      // probably and it's more of a mess. But leaving this here anyway.
-      $pluginHelper = \Drupal::service('search_api.plugin_helper');
-      $datasource = $pluginHelper->createDatasourcePlugins($index, 'entity:' . $entity_type_id);
-    }
-    if (!$datasource) {
-      \Drupal::messenger()->addMessage(t('Failed to update the directories search index with new bundle'), MessengerInterface::TYPE_ERROR);
-      return;
-    }
-
-    $configuration = $datasource->getConfiguration();
-    $configuration['bundles']['default'] = FALSE;
-    if (!in_array($entity_bundle, $configuration['bundles']['selected'])) {
-      $configuration['bundles']['selected'][] = $entity_bundle;
-    }
-    $datasource->setConfiguration($configuration);
-
-    $index_field = $index->getField('rendered_item');
-    if ($index_field) {
-      $configuration = $index_field->getConfiguration();
-      $configuration['view_mode']['entity:node'][$entity_bundle] = 'directory_index';
-      $index_field->setConfiguration($configuration);
-    }
-
-    $index->save();
-
-    // Also set the default view mode for the directory view listing.
-    $view = View::load('localgov_directory_channel');
-    if ($view) {
-      $display = $view->get('display');
-      if (isset($display['node_embed']['display_options']['row'])) {
-        $display['node_embed']['display_options']['row']['options']['view_modes']['entity:node'][$entity_bundle] = 'teaser';
-      }
-      elseif (isset($display['default']['display_options']['row'])) {
-        $display['default']['display_options']['row']['options']['view_modes']['entity:node'][$entity_bundle] = 'teaser';
-      }
-      $view->set('display', $display);
-      $view->save();
-    }
+  if ($field->getName() == Directory::CHANNEL_SELECTION_FIELD) {
+    \Drupal::classResolver(ConfigurationHelper::class)->insertedDirectoryChannelField($field);
   }
-
-  // Setup indexing on Facet selection field of a Directory entry content type.
-  $is_node_field = $field->getTargetEntityTypeId() === 'node';
-  $is_adding_facet_selection_field = $field->getName() === Directory::FACET_SELECTION_FIELD;
-  $is_adding_channel_selection_field = $field->getName() === Directory::CHANNEL_SELECTION_FIELD;
-  $dir_search_index = Index::load('localgov_directories_index_default');
-  $has_dir_search_index = $dir_search_index;
-
-  $entity_bundle = $field->getTargetBundle();
-  $entity_field_defs = Drupal::service('entity_field.manager')->getFieldDefinitions('node', $entity_bundle);
-  $has_channel_selection_field = array_key_exists(Directory::CHANNEL_SELECTION_FIELD, $entity_field_defs);
-  $has_facet_selection_field = array_key_exists(Directory::FACET_SELECTION_FIELD, $entity_field_defs);
-  $has_both_facet_and_channel_fields = (($is_adding_channel_selection_field and $has_facet_selection_field) or ($is_adding_facet_selection_field and $has_channel_selection_field));
-  $is_new_directory_entry_content_type = ($is_node_field and $has_both_facet_and_channel_fields);
-  if ($is_new_directory_entry_content_type and $has_dir_search_index) {
-    localgov_directories_add_facet_field_to_index($dir_search_index);
-    localgov_directories_create_dir_facet();
+  elseif ($field->getName() == Directory::FACET_SELECTION_FIELD) {
+    \Drupal::classResolver(ConfigurationHelper::class)->insertedFacetField($field);
   }
-
-  // Setup Directory search block.
-  $is_creating_directory_entry_content_type = ($is_node_field and $is_adding_channel_selection_field);
-  if ($is_creating_directory_entry_content_type) {
-    $content_type = $field->getTargetBundle();
-    localgov_directories_add_block_to_content_type_sidebar(Directory::CHANNEL_SEARCH_BLOCK, $content_type);
+  elseif ($field->getName() == Directory::TITLE_SORT_FIELD) {
+    \Drupal::classResolver(ConfigurationHelper::class)->insertedTitleSortField($field);
   }
 }
 
@@ -301,130 +226,6 @@ function template_preprocess_localgov_directories_facets(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
-}
-
-/**
- * Setup indexing on the Facet selection field of Directory entries.
- *
- * This assumes that the localgov_directory_facets_select field is part of a
- * Directory entry content type.
- */
-function localgov_directories_add_facet_field_to_index(IndexInterface $dir_search_index) {
-
-  $has_facet_index_field = $dir_search_index->getField(Directory::FACET_INDEXING_FIELD);
-  if ($has_facet_index_field) {
-    return;
-  }
-
-  $new_facet_index_field = new SearchIndexField($dir_search_index, Directory::FACET_INDEXING_FIELD);
-  $new_facet_index_field->setLabel('Facets');
-  $new_facet_index_field->setDataSourceId('entity:node');
-  $new_facet_index_field->setPropertyPath(Directory::FACET_SELECTION_FIELD);
-  $new_facet_index_field->setType('integer');
-  $new_facet_index_field->setDependencies([
-    'config' => [
-      'field.storage.node.' . Directory::FACET_SELECTION_FIELD,
-    ],
-  ]);
-  $dir_search_index->addField($new_facet_index_field);
-  $dir_search_index->save();
-}
-
-/**
- * Import config entity for the directory Facet.
- */
-function localgov_directories_create_dir_facet() {
-
-  $has_dir_facet_config = Facet::load(Directory::FACET_CONFIG_ENTITY_ID);
-  if ($has_dir_facet_config) {
-    return;
-  }
-
-  $conditional_config_path = \Drupal::service('extension.list.module')->getPath('localgov_directories') . '/config/conditional';
-  $import_result = localgov_directories_import_config_entity('facets_facet', $conditional_config_path, Directory::FACET_CONFIG_FILE);
-  if ($import_result) {
-    Drupal::service('config.installer')->installOptionalConfig();
-  }
-}
-
-/**
- * Create new config entity from given config file.
- *
- * @param string $entity_type
- *   Example: facets_facet.
- * @param string $config_path
- *   Example: modules/foo/config/bar.
- * @param string $config_filename
- *   Example: views.view.bar.
- *
- * @see https://www.metaltoad.com/blog/programmatically-importing-drupal-8-field-configurations
- * @see https://stackoverflow.com/a/52277490
- */
-function localgov_directories_import_config_entity(string $entity_type, string $config_path, string $config_filename): bool {
-
-  $config_src = new ConfigFileStorage($config_path);
-  if (empty($config_src)) {
-    return FALSE;
-  }
-
-  $config_values = $config_src->read($config_filename);
-  if (empty($config_values)) {
-    return FALSE;
-  }
-
-  try {
-    Drupal::service('entity_type.manager')->getStorage($entity_type)->create($config_values)->save();
-  }
-  catch (Exception $e) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Failed to create new config entity: %filename.  Error: %msg', [
-      '%filename' => $config_filename,
-      '%msg' => $e->getMessage(),
-    ]);
-
-    return FALSE;
-  }
-
-  return TRUE;
-}
-
-/**
- * Update a block's visibility.
- *
- * The given block should appear in pages for the given content type.
- */
-function localgov_directories_add_block_to_content_type_sidebar(string $block_id, string $content_type): bool {
-
-  $block_config = Block::load($block_id);
-  if (empty($block_config)) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Block %block-id is missing.  Cannot update its visibility settings.', [
-      '%block-id' => $block_id,
-    ]);
-
-    return FALSE;
-  }
-
-  try {
-    $block_visibility_config = $block_config->getVisibility();
-    $block_visibility_config['node_type']['bundles'][$content_type] = $content_type;
-    $block_config->setVisibilityConfig('node_type', $block_visibility_config['node_type']);
-    $block_config->save();
-  }
-  catch (Exception $e) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Failed to add %content-type content type to %block-id block: %error-msg', [
-      '%content-type' => $content_type,
-      '%block-id' => $block_id,
-      '%error-msg' => $e->getMessage(),
-    ]);
-
-    return FALSE;
-  }
-
-  Drupal::service('logger.factory')->get('localgov_directories')->notice('Added %content-type content type to %block-id block.', [
-    '%content-type' => $content_type,
-    '%block-id' => $block_id,
-  ]);
-
-  return TRUE;
 }
 
 /**

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -5,25 +5,18 @@
  * Provides a directory facets entity type.
  */
 
-use Drupal\block\Entity\Block;
-use Drupal\Core\Config\FileStorage as ConfigFileStorage;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Element;
-use Drupal\facets\Entity\Facet;
 use Drupal\field\FieldConfigInterface;
 use Drupal\localgov_directories\ConfigurationHelper;
 use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
 use Drupal\localgov_roles\RolesHelper;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\Entity\PathautoPattern;
-use Drupal\search_api\Entity\Index;
 use Drupal\search_api\IndexInterface;
-use Drupal\search_api\Item\Field as SearchIndexField;
 use Drupal\localgov_directories\Constants as Directory;
-use Drupal\views\Entity\View;
 
 /**
  * Implements hook_theme().
@@ -163,37 +156,8 @@ function localgov_directories_field_config_insert(FieldConfigInterface $field) {
  * Implements hook_ENTITY_TYPE_delete().
  */
 function localgov_directories_field_config_delete(FieldConfigInterface $field) {
-  // If a content type can no longer be added to a directory channel remove
-  // from index.
-  if (
-    $field->getName() == 'localgov_directory_channels' &&
-    $field->getTargetEntityTypeId() == 'node' &&
-    ($index = Index::load('localgov_directories_index_default'))
-  ) {
-    $entity_type_id = 'node';
-    $entity_bundle = $field->getTargetBundle();
-
-    $index = Index::load('localgov_directories_index_default');
-    $datasource = $index->getDatasource('entity:' . $entity_type_id);
-    if (!$datasource) {
-      return;
-    }
-
-    $configuration = $datasource->getConfiguration();
-    $configuration['bundles']['default'] = FALSE;
-    if (($key = array_search($entity_bundle, $configuration['bundles']['selected'])) !== FALSE) {
-      unset($configuration['bundles']['selected'][$key]);
-    }
-    $datasource->setConfiguration($configuration);
-    $index->save();
-  }
-
-  $is_node_field = $field->getTargetEntityTypeId() === 'node';
-  $is_channel_selection_field = $field->getName() === Directory::CHANNEL_SELECTION_FIELD;
-  $is_defunct_directory_entry_content_type = ($is_node_field and $is_channel_selection_field);
-  if ($is_defunct_directory_entry_content_type) {
-    $content_type = $field->getTargetBundle();
-    localgov_directories_remove_block_from_content_type_sidebar(Directory::CHANNEL_SEARCH_BLOCK, $content_type);
+  if ($field->getName() == Directory::CHANNEL_SELECTION_FIELD) {
+    \Drupal::classResolver(ConfigurationHelper::class)->deletedDirectoryChannelField($field);
   }
 }
 
@@ -226,51 +190,6 @@ function template_preprocess_localgov_directories_facets(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
-}
-
-/**
- * Update a block's visibility.
- *
- * The given block should **not** appear in pages for the given content type.
- */
-function localgov_directories_remove_block_from_content_type_sidebar(string $block_id, string $content_type): bool {
-
-  $block_config = Block::load($block_id);
-  if (empty($block_config)) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Block %block-id is missing.  Cannot update its visibility settings.', [
-      '%block-id' => $block_id,
-    ]);
-
-    return FALSE;
-  }
-
-  try {
-    $block_visibility_config = $block_config->getVisibility();
-
-    if (empty($block_visibility_config['node_type']['bundles'][$content_type])) {
-      return FALSE;
-    }
-
-    unset($block_visibility_config['node_type']['bundles'][$content_type]);
-    $block_config->setVisibilityConfig('node_type', $block_visibility_config['node_type']);
-    $block_config->save();
-  }
-  catch (Exception $e) {
-    Drupal::service('logger.factory')->get('localgov_directories')->error('Failed to remove %content-type content type from %block-id block: %error-msg', [
-      '%content-type' => $content_type,
-      '%block-id' => $block_id,
-      '%error-msg' => $e->getMessage(),
-    ]);
-
-    return FALSE;
-  }
-
-  Drupal::service('logger.factory')->get('localgov_directories')->notice('Removed %content-type content type from %block-id block.', [
-    '%content-type' => $content_type,
-    '%block-id' => $block_id,
-  ]);
-
-  return TRUE;
 }
 
 /**

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -243,7 +243,7 @@ class ConfigurationHelper implements ContainerInjectionInterface {
    * Directory entry content type.
    *
    * @param \Drupal\search_api\IndexInterface $index
-   *   The index to the facet field to.
+   *   The index to add the facet field to.
    */
   protected function indexAddFacetField(IndexInterface $index): void {
     if ($index->getField(Constants::FACET_INDEXING_FIELD)) {
@@ -328,7 +328,8 @@ class ConfigurationHelper implements ContainerInjectionInterface {
   /**
    * Update a block's visibility to add to content type.
    *
-   * The given block should appear sidebar pages for the given content type.
+   * The given block should appear in the sidebars of pages for the given
+   * content type.
    *
    * @param string $block_id
    *   The block to update visibility for.
@@ -375,8 +376,8 @@ class ConfigurationHelper implements ContainerInjectionInterface {
   /**
    * Update a block's visibility to remove from content type.
    *
-   * The given block should no longer appear sidebar pages for the given
-   * content type.
+   * The given block should no longer appear in the sidebars of pages for the
+   * given content type.
    *
    * @param string $block_id
    *   The block to update visibility for.

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\localgov_directories;
+
+use Drupal\block\BlockInterface;
+use Drupal\Core\Config\FileStorage as ConfigFileStorage;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Item\Field as SearchIndexField;
+use Drupal\views\ViewEntityInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Update index and block configurations for changed entities and fields.
+ */
+class ConfigurationHelper implements ContainerInjectionInterface {
+
+  /**
+   * The Search API directory index.
+   *
+   * @var \Drupal\search_api\Entity\IndexInterface
+   */
+  protected ?IndexInterface $index;
+
+  /**
+   * The directory view.
+   *
+   * @var \Drupal\views\ViewEntityInterface
+   */
+  protected ?ViewEntityInterface $view;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * DirectoryExtraFieldDisplay constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * Get index to work on.
+   */
+  public function getIndex(): IndexInterface {
+    return $this->index ?? $this->entityTypeManager->getStorage('search_api_index')->load(Constants::DEFAULT_INDEX);
+  }
+
+  /**
+   * Get directory view to work on.
+   */
+  public function getView(): ViewEntityInterface {
+    return $this->view ?? $this->entityTypeManager->getStorage('view')->load('localgov_directory_channel');
+  }
+
+  /**
+   * Act on a Directory channel field being added.
+   */
+  public function insertedDirectoryChannelField(FieldConfigInterface $field) {
+    // Only working for nodes at the moment.
+    $entity_type_id = $field->getTargetEntityTypeId();
+    $entity_bundle = $field->getTargetBundle();
+    // Index changes.
+    if ($index = $this->getIndex()) {
+      $this->indexAddBundle($index, $entity_type_id, $entity_bundle);
+      $this->renderedItemAddBundle($index, $entity_type_id, $entity_bundle);
+      $this->indexAddChannelsField($index);
+      $index->save();
+    }
+    if ($view = $this->getView()) {
+      $this->viewSetViewMode($view, $entity_type_id, $entity_bundle);
+      $view->save();
+    }
+    $this->addBlockToContentType(Constants::CHANNEL_SEARCH_BLOCK, $entity_bundle);
+  }
+
+  /**
+   * Act on Directory facet field being added.
+   */
+  public function insertedFacetField(FieldConfigInterface $field) {
+    if ($index = $this->getIndex()) {
+      $this->indexAddFacetField($index);
+      $index->save();
+    }
+    $this->createFacet();
+  }
+
+  /**
+   * Act on Directory title sort field being added.
+   */
+  public function insertedTitleSortField(FieldConfigInterface $field) {
+    if ($index = $this->getIndex()) {
+      $this->indexAddTitleSortField($index);
+      $index->save();
+    }
+  }
+
+  /**
+   * Create new config entity from given config file.
+   *
+   * @param string $entity_type
+   *   Example: facets_facet.
+   * @param string $config_path
+   *   Example: modules/foo/config/bar.
+   * @param string $config_filename
+   *   Example: views.view.bar.
+   */
+  public function importConfigEntity(string $entity_type, string $config_path, string $config_filename): bool {
+    $config_src = new ConfigFileStorage($config_path);
+    if (empty($config_src)) {
+      return FALSE;
+    }
+
+    $config_values = $config_src->read($config_filename);
+    if (empty($config_values)) {
+      return FALSE;
+    }
+
+    try {
+      $this->entityTypeManager->getStorage($entity_type)->create($config_values)->save();
+    }
+    catch (Exception $e) {
+      Drupal::service('logger.factory')->get('localgov_directories')->error('Failed to create new config entity: %filename.  Error: %msg', [
+        '%filename' => $config_filename,
+        '%msg' => $e->getMessage(),
+      ]);
+
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Setup indexing on the Facet selection field of Directory entries.
+   *
+   * This assumes that the localgov_directory_facets_select field is part of a
+   * Directory entry content type.
+   */
+  protected function indexAddFacetField(IndexInterface $index) {
+    if ($index->getField(Constants::FACET_INDEXING_FIELD)) {
+      return;
+    }
+
+    $field = new SearchIndexField($index, Constants::FACET_INDEXING_FIELD);
+    $field->setLabel('Facets');
+    $field->setDataSourceId('entity:node');
+    $field->setPropertyPath(Constants::FACET_SELECTION_FIELD);
+    $field->setType('integer');
+    $field->setDependencies([
+      'config' => [
+        'field.storage.node.' . Constants::FACET_SELECTION_FIELD,
+      ],
+    ]);
+    $index->addField($field);
+  }
+
+  /**
+   * Setup indexing on the Title Sort field of Directory entries.
+   */
+  protected function indexAddTitleSortField(IndexInterface &$index) {
+    if ($index->getField(Constants::TITLE_SORT_FIELD)) {
+      return;
+    }
+
+    $field = new SearchIndexField($index, Constants::TITLE_SORT_FIELD);
+    $field->setLabel('Title (sort)');
+    $field->setDataSourceId('entity:node');
+    $field->setPropertyPath(Constants::TITLE_SORT_FIELD);
+    $field->setType('string');
+    $field->setDependencies([
+      'config' => [
+        'field.storage.node.' . Constants::TITLE_SORT_FIELD,
+      ],
+    ]);
+    $index->addField($field);
+  }
+
+  /**
+   * Setup indexing on the Directory channels field of Directory entries.
+   */
+  protected function indexAddChannelsField(IndexInterface $index) {
+    if ($index->getField(Constants::CHANNEL_SELECTION_FIELD)) {
+      return;
+    }
+
+    $field = new SearchIndexField($index, Constants::CHANNEL_SELECTION_FIELD);
+    $field->setLabel('Directory channels');
+    $field->setDataSourceId('entity:node');
+    $field->setPropertyPath(Constants::CHANNEL_SELECTION_FIELD);
+    $field->setType('string');
+    $field->setDependencies([
+      'config' => [
+        'field.storage.node.' . Constants::CHANNEL_SELECTION_FIELD,
+      ],
+    ]);
+    $index->addField($field);
+  }
+
+  /**
+   * Import config entity for the directory Facet.
+   */
+  public function createFacet() {
+    if ($this->entityTypeManager->getStorage('facets_facet')->load(Constants::FACET_CONFIG_ENTITY_ID)) {
+      return;
+    }
+
+    $conditional_config_path = \Drupal::service('extension.list.module')->getPath('localgov_directories') . '/config/conditional';
+    if ($this->importConfigEntity('facets_facet', $conditional_config_path, Constants::FACET_CONFIG_FILE)) {
+      \Drupal::service('config.installer')->installOptionalConfig();
+    }
+  }
+
+  /**
+   * Update a block's visibility.
+   *
+   * @todo logger
+   *
+   * The given block should appear sidebar pages for the given content type.
+   */
+  public function addBlockToContentType(string $block_id, string $content_type): bool {
+    $block_config = $this->entityTypeManager->getStorage('block')->load($block_id);
+    if (!$block_config instanceof BlockInterface) {
+      \Drupal::service('logger.factory')->get('localgov_directories')->error('Block %block-id is missing.  Cannot update its visibility settings.', [
+        '%block-id' => $block_id,
+      ]);
+
+      return FALSE;
+    }
+
+    try {
+      $visibility = $block_config->getVisibility();
+      $visibility['node_type']['bundles'][$content_type] = $content_type;
+      $block_config->setVisibilityConfig('node_type', $visibility['node_type']);
+      $block_config->save();
+    }
+    catch (Exception $e) {
+      \Drupal::service('logger.factory')->get('localgov_directories')->error('Failed to add %content-type content type to %block-id block: %error-msg', [
+        '%content-type' => $content_type,
+        '%block-id' => $block_id,
+        '%error-msg' => $e->getMessage(),
+      ]);
+
+      return FALSE;
+    }
+
+    \Drupal::service('logger.factory')->get('localgov_directories')->notice('Added %content-type content type to %block-id block.', [
+      '%content-type' => $content_type,
+      '%block-id' => $block_id,
+    ]);
+
+    return TRUE;
+  }
+
+  protected function indexAddBundle(IndexInterface $index, $entity_type_id, $entity_bundle) {
+    $datasource = $this->indexGetDatasource($index, $entity_type_id);
+    if (!$datasource) {
+      \Drupal::messenger()->addMessage(t('Failed to update the directories search index with new bundle'), MessengerInterface::TYPE_ERROR);
+      return;
+    }
+
+    $configuration = $datasource->getConfiguration();
+    $configuration['bundles']['default'] = FALSE;
+    if (!in_array($entity_bundle, $configuration['bundles']['selected'])) {
+      $configuration['bundles']['selected'][] = $entity_bundle;
+    }
+    $datasource->setConfiguration($configuration);
+  }
+
+  protected function viewSetViewMode(ViewEntityInterface $view, $entity_type_id, $entity_bundle) {
+    // Also set the default view mode for the directory view listing.
+    $display = $view->get('display');
+    if (isset($display['node_embed']['display_options']['row'])) {
+      $display['node_embed']['display_options']['row']['options']['view_modes']['entity:' . $entity_type_id][$entity_bundle] = 'teaser';
+    }
+    elseif (isset($display['default']['display_options']['row'])) {
+      $display['default']['display_options']['row']['options']['view_modes']['entity:' . $entity_type_id][$entity_bundle] = 'teaser';
+    }
+    $view->set('display', $display);
+  }
+
+  protected function renderedItemAddBundle(IndexInterface $index, $entity_type_id, $entity_bundle) {
+    $index_field = $index->getField('rendered_item');
+    if ($index_field) {
+      $configuration = $index_field->getConfiguration();
+      $configuration['view_mode']['entity:' . $entity_type_id][$entity_bundle] = 'directory_index';
+      $index_field->setConfiguration($configuration);
+    }
+  }
+
+  protected function indexGetDatasource(IndexInterface $index, $entity_type_id) {
+    $datasource = $index->getDatasource('entity:' . $entity_type_id);
+    if (!$datasource) {
+      // If the content:node datasource has been lost so have the fields most
+      // probably and it's more of a mess. But leaving this here anyway.
+      $pluginHelper = \Drupal::service('search_api.plugin_helper');
+      $datasource = $pluginHelper->createDatasourcePlugins($index, 'entity:' . $entity_type_id);
+    }
+
+    return $datasource;
+  }
+
+  /**
+   * Act on Directory channel field being removed.
+   */
+
+  /**
+   * Act on Directory facet field being removed.
+   */
+
+  /**
+   * Act on Directory title sort field being removed.
+   */
+
+}

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -9,9 +9,13 @@ namespace Drupal\localgov_directories;
  */
 class Constants {
 
-  const CHANNEL_SELECTION_FIELD = 'localgov_directory_channels';
+  const DEFAULT_INDEX = 'localgov_directories_index_default';
 
   const CHANNEL_SEARCH_BLOCK = 'localgov_directories_channel_search_block';
+
+  const CHANNEL_SELECTION_FIELD = 'localgov_directory_channels';
+
+  const TITLE_SORT_FIELD = 'localgov_directory_title_sort';
 
   const FACET_INDEXING_FIELD = 'localgov_directory_facets_filter';
 

--- a/tests/src/Kernel/IndexTitleSortTest.php
+++ b/tests/src/Kernel/IndexTitleSortTest.php
@@ -83,6 +83,8 @@ class IndexTitleSortTest extends KernelTestBase {
       'search_api',
       'localgov_directories',
     ]);
+    // Enable localgov_directories_db such that all hooks called.
+    $this->container->get('module_installer')->install(['localgov_directories_db'], FALSE);
 
     // @todo check if we need this in the end.
     if (!Utility::isRunningInCli()) {
@@ -102,8 +104,6 @@ class IndexTitleSortTest extends KernelTestBase {
     // Add content type to search index.
     $this->createEntityReferenceField('node', $item_type_name, 'localgov_directory_channels', $this->randomString(), 'node');
 
-    // Enable localgov_directories_db such that all hooks called.
-    $this->container->get('module_installer')->install(['localgov_directories_db'], FALSE);
 
     $this->index = Index::load('localgov_directories_index_default');
     // We're not testing rendered item, and it requires pulling in a whole load

--- a/tests/src/Kernel/IndexTitleSortTest.php
+++ b/tests/src/Kernel/IndexTitleSortTest.php
@@ -104,7 +104,6 @@ class IndexTitleSortTest extends KernelTestBase {
     // Add content type to search index.
     $this->createEntityReferenceField('node', $item_type_name, 'localgov_directory_channels', $this->randomString(), 'node');
 
-
     $this->index = Index::load('localgov_directories_index_default');
     // We're not testing rendered item, and it requires pulling in a whole load
     // of dependencies.


### PR DESCRIPTION
Working in manual testing

To do:

- [x]  * Automated testing on index save the fields are still removed.
- [x]  * Also tidy the hook delete block removal.
- [x]  * Add user requirements messaging if backend / content types missing.
- [x]  * Optionally also act on enable/disable of search index for the block.