### PR TITLE
Add update hook to add pathauto pattern should it not exist yet #254.

### DIFF
--- a/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
+++ b/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
@@ -5,13 +5,18 @@
  * Update functions for the LocalGov Directories Promo Page.
  */
 
+use Drupal\node\Entity\Node;
 use Drupal\pathauto\Entity\PathautoPattern;
 
 /**
  * Adds pathauto pattern if there is not one yet.
  */
 function localgov_directories_promo_page_update_8001() {
-  $pattern = PathautoPattern::load('localgov_directory_promo_page');
+  $pathauto = \Drupal::service('pathauto.generator');
+  $entity = Node::create([
+    'type' => 'localgov_directory_promo_page',
+  ]);
+  $pattern = $pathauto->getPatternByEntity($entity);
   if (empty($pattern)) {
     $pattern = PathautoPattern::create([
       'id' => 'localgov_directories_promo_page',

--- a/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
+++ b/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Update functions for the LocalGov Directories Promo Page.
+ */
+
+use Drupal\pathauto\Entity\PathautoPattern;
+
+/**
+ * Adds pathauto pattern if there is not one yet.
+ */
+function localgov_directories_promo_page_update_8001() {
+  $pattern = PathautoPattern::load('localgov_directory_promo_page');
+  if (empty($pattern)) {
+    $pattern = PathautoPattern::create([
+      'id' => 'localgov_directories_promo_page',
+      'label' => 'Directory Promo Page',
+      'type' => 'canonical_entities:node',
+      'pattern' => '[node:title]',
+      'selection_logic' => 'and',
+      'weight' => -5,
+    ]);
+    $pattern->getSelectionConditions()->addInstanceId(
+      'cf0a2bbc-3869-4912-a0e7-0f25ba4fcd1e', [
+        'id' => 'entity_bundle:node',
+        'bundles' => [
+          'localgov_directory_promo_page' => 'localgov_directory_promo_page',
+        ],
+        'negate' => FALSE,
+        'context_mapping' => [
+          'node' => 'node',
+        ],
+        'uuid' => 'cf0a2bbc-3869-4912-a0e7-0f25ba4fcd1e',
+      ],
+    );
+    $pattern->save();
+  }
+}


### PR DESCRIPTION
To test:
 * Install version of localgov_directory_promo_page _before_ https://github.com/localgovdrupal/localgov_directories/commit/e142ff22438ed025d511c71f4fc12fa451e2e789 so current 2.3.7 version will do.
 * Enable localgov_directory_promo_page module
 * Then switch to this branch and run updb

The pathauto pattern should be exactly the same, as installing from scratch at HEAD.

Stretch goal. Do the same with a pathauto pattern added, it shouldn't change.