### PR TITLE
Configuration Helper get(Index|View) functions can return NULL.

### DIFF
--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -124,14 +124,14 @@ class ConfigurationHelper implements ContainerInjectionInterface {
   /**
    * Get index to work on.
    */
-  public function getIndex(): IndexInterface {
+  public function getIndex(): ?IndexInterface {
     return $this->index ?? $this->entityTypeManager->getStorage('search_api_index')->load(Constants::DEFAULT_INDEX);
   }
 
   /**
    * Get directory view to work on.
    */
-  public function getView(): ViewEntityInterface {
+  public function getView(): ?ViewEntityInterface {
     return $this->view ?? $this->entityTypeManager->getStorage('view')->load('localgov_directory_channel');
   }
 


### PR DESCRIPTION
All calls to these methods already are actually checking if a value is returned. It makes sense that there are times there isn't a view or index (import for example). There are other checks later that it shoud operate on these indexes and views.

Fixes #259

Longer description https://github.com/localgovdrupal/localgov_directories/issues/259#issuecomment-1387267153