### PR TITLE
Drupal 10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test localgovdrupal/localgov_directories drupal-module
 on:
   push:
     branches:
-      - '2.x'
+      - '3.x'
   pull_request:
     branches:
-      - '2.x'
+      - '3.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_directories
@@ -21,13 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -105,13 +104,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -141,13 +139,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -176,13 +173,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,16 +78,21 @@ jobs:
 
       - name: Create LocalGov Drupal project
         run: |
+          composer global config github-oauth.github.com ${{ github.token }}
           composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
           composer --working-dir=./html require --no-install localgovdrupal/localgov:${{ matrix.localgov-version }}-dev
           composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer --working-dir=./html install
 
+      - name: DON'T MERGE THIS - Require Drupal 10 compatible branches
+        run: |
+          composer --working-dir=./html require localgovdrupal/localgov_core:"dev-feature/drupal-10 as 2.2.0"
+          composer --working-dir=./html require localgovdrupal/localgov_geo:"dev-feature/drupal-10 as 1.3.0"
+
       - name: Obtain the test target using Composer
         if: env.HEAD_USER == 'localgovdrupal'
         run: |
-          composer --working-dir=html config repositories.1 vcs git@github.com:${LOCALGOV_DRUPAL_PROJECT}.git
-          composer global config github-oauth.github.com ${{ github.token }}
+          composer --working-dir=./html config repositories.1 vcs git@github.com:${LOCALGOV_DRUPAL_PROJECT}.git
           composer --working-dir=./html require --with-all-dependencies ${LOCALGOV_DRUPAL_PROJECT}:"${COMPOSER_REF} as ${LATEST_RELEASE}"
 
       - name: Obtain the test target using Git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-##
-# Managed by https://github.com/localgovdrupal/github_workflow_manager
----
 name: Test localgovdrupal/localgov_directories drupal-module
 
 on:
@@ -24,13 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -108,13 +105,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -144,13 +141,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -179,13 +176,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
-        "localgovdrupal/localgov_core": "^2.1",
-        "localgovdrupal/localgov_geo": "^1.1"
+        "localgovdrupal/localgov_core": "dev-feature/drupal-10 as 2.2.0",
+        "localgovdrupal/localgov_geo": "dev-feature/drupal-10 as 1.3.0"
     },
     "require-dev": {
         "localgovdrupal/localgov_services": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "localgovdrupal/localgov_geo": "dev-feature/drupal-10 as 1.3.0"
     },
     "require-dev": {
-        "localgovdrupal/localgov_services": "^2.0",
-        "localgovdrupal/localgov_openreferral": "^1.0",
-        "localgovdrupal/localgov_paragraphs": "^2.0"
+        "localgovdrupal/localgov_services": "dev-feature/drupal-10 as 2.1.0",
+        "localgovdrupal/localgov_openreferral": "dev-feature/drupal-10 as 1.1.0",
+        "localgovdrupal/localgov_paragraphs": "dev-feature/drupal-10 as 2.3.0"
     },
     "suggest": {
         "localgovdrupal/localgov_openreferral": "Enables Open Referral output of Directories",

--- a/config/optional/block.block.localgov_directories_channel_search_block.yml
+++ b/config/optional/block.block.localgov_directories_channel_search_block.yml
@@ -21,7 +21,7 @@ settings:
     node: '@node.node_route_context:node'
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false

--- a/config/optional/block.block.localgov_directories_channel_search_block_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_channel_search_block_scarfolk.yml
@@ -21,7 +21,7 @@ settings:
     node: '@node.node_route_context:node'
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false

--- a/config/optional/block.block.localgov_directories_facets.yml
+++ b/config/optional/block.block.localgov_directories_facets.yml
@@ -22,7 +22,7 @@ settings:
   block_id: localgov_directories_facets
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false

--- a/config/optional/block.block.localgov_directories_facets_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_facets_scarfolk.yml
@@ -22,7 +22,7 @@ settings:
   block_id: localgov_directories_facets
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false

--- a/localgov_directories.info.yml
+++ b/localgov_directories.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories'
 type: module
 description: 'Provides a directory facets entity.'
 package: LocalGov Drupal
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:address

--- a/localgov_directories.info.yml
+++ b/localgov_directories.info.yml
@@ -6,7 +6,9 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:address
   - drupal:block
+  - drupal:image
   - drupal:link
+  - drupal:media
   - drupal:node
   - drupal:path
   - drupal:telephone

--- a/localgov_directories.info.yml
+++ b/localgov_directories.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides a directory facets entity.'
 package: LocalGov Drupal
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:address
   - drupal:block

--- a/modules/localgov_directories_db/localgov_directories_db.info.yml
+++ b/modules/localgov_directories_db/localgov_directories_db.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Directories Database'
 description: 'Installs initial SQL database index and configuration for Directories.'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_directories_db/tests/Kernel/InstallTest.php
+++ b/modules/localgov_directories_db/tests/Kernel/InstallTest.php
@@ -21,6 +21,7 @@ class InstallTest extends KernelTestBase {
     'system',
     'node',
     'field',
+    'image',
     'link',
     'media',
     'address',
@@ -47,6 +48,8 @@ class InstallTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installSchema('user', ['users_data']);
     $this->installConfig([
+      'image',
+      'media',
       'node',
       'localgov_directories',
       'search_api_db',

--- a/modules/localgov_directories_location/localgov_directories_location.info.yml
+++ b/modules/localgov_directories_location/localgov_directories_location.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides location fields and functionality for directory entries.'
 package: LocalGov Drupal
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - inline_entity_form:inline_entity_form
   - localgov_directories:localgov_directories

--- a/modules/localgov_directories_location/localgov_directories_location.info.yml
+++ b/modules/localgov_directories_location/localgov_directories_location.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories Location'
 type: module
 description: 'Provides location fields and functionality for directory entries.'
 package: LocalGov Drupal
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - inline_entity_form:inline_entity_form

--- a/modules/localgov_directories_or/localgov_directories_or.info.yml
+++ b/modules/localgov_directories_or/localgov_directories_or.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories: Open Referral'
 type: module
 description: 'Adds mappings for Facets for Open Referral.'
 package: LocalGov Drupal (Experimental)
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - localgov_directories:localgov_directories

--- a/modules/localgov_directories_or/localgov_directories_or.info.yml
+++ b/modules/localgov_directories_or/localgov_directories_or.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Adds mappings for Facets for Open Referral.'
 package: LocalGov Drupal (Experimental)
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - localgov_directories:localgov_directories
   - localgov_openreferral:localgov_openreferral

--- a/modules/localgov_directories_or/src/FacetMapping.php
+++ b/modules/localgov_directories_or/src/FacetMapping.php
@@ -73,6 +73,7 @@ class FacetMapping implements ContainerInjectionInterface {
     // Add or remove Open Referral mappings from facet types as required by
     // their listing in directories with Open Referral entries.
     $facet_query = $facet_storage->getQuery()
+      ->accessCheck(TRUE)
       ->execute();
     foreach ($facet_query as $facet_type) {
       if (in_array($facet_type, $openreferral_facets) &&

--- a/modules/localgov_directories_org/localgov_directories_org.info.yml
+++ b/modules/localgov_directories_org/localgov_directories_org.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides a standard organisation type for either as directory entry, or for other Open Referral compatible entries.'
 package: LocalGov Drupal
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - field_group:field_group
   - localgov_directories:localgov_directories

--- a/modules/localgov_directories_org/localgov_directories_org.info.yml
+++ b/modules/localgov_directories_org/localgov_directories_org.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories Organisation'
 type: module
 description: 'Provides a standard organisation type for either as directory entry, or for other Open Referral compatible entries.'
 package: LocalGov Drupal
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - field_group:field_group

--- a/modules/localgov_directories_org/tests/Functional/DirectoryOrgTest.php
+++ b/modules/localgov_directories_org/tests/Functional/DirectoryOrgTest.php
@@ -21,12 +21,12 @@ class DirectoryOrgTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.

--- a/modules/localgov_directories_page/localgov_directories_page.info.yml
+++ b/modules/localgov_directories_page/localgov_directories_page.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Directories Page'
 type: module
 description: 'Provides a basic entry type for directory channels.'
 package: LocalGov Drupal
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:link
   - address:address

--- a/modules/localgov_directories_page/tests/src/Functional/DirectoryPageTest.php
+++ b/modules/localgov_directories_page/tests/src/Functional/DirectoryPageTest.php
@@ -21,12 +21,12 @@ class DirectoryPageTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.

--- a/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,7 +19,13 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
+    'entity_reference_revisions',
+    'node',
+    'paragraphs',
+    'paragraphs_library',
+    'path',
     'system',
+    'toolbar',
     'user',
     'localgov_roles',
   ];
@@ -29,14 +35,20 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->installConfig(['user', 'localgov_roles']);
+
+    $this->installConfig([
+      'user',
+    ]);
   }
 
   /**
    * Check default roles applied.
    */
   public function testEnablingRolesModule() {
-    $this->container->get('module_installer')->install(['localgov_directories_page']);
+    $this->container->get('module_installer')->install([
+
+      'localgov_directories_page',
+    ]);
 
     $editor = Role::load(RolesHelper::EDITOR_ROLE);
     $author = Role::load(RolesHelper::AUTHOR_ROLE);

--- a/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,12 +19,12 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
-    'entity_reference_revisions',
+    'field',
     'node',
-    'paragraphs',
-    'paragraphs_library',
     'path',
+    'role_delegation',
     'system',
+    'text',
     'toolbar',
     'user',
     'localgov_roles',
@@ -35,9 +35,9 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-
     $this->installConfig([
       'user',
+      'localgov_roles',
     ]);
   }
 
@@ -46,7 +46,6 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   public function testEnablingRolesModule() {
     $this->container->get('module_installer')->install([
-
       'localgov_directories_page',
     ]);
 

--- a/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,15 +19,33 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
+    'address',
+    'block',
+    'facets',
     'field',
+    'field_group',
+    'filter',
+    'image',
+    'link',
+    'media',
+    'media_library',
     'node',
     'path',
+    'path_alias',
+    'pathauto',
     'role_delegation',
+    'search_api',
+    'search_api_db',
     'system',
+    'telephone',
     'text',
+    'token',
     'toolbar',
     'user',
+    'views',
     'localgov_roles',
+    'localgov_directories',
+    'localgov_directories_page',
   ];
 
   /**
@@ -35,9 +53,17 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('search_api_task');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
     $this->installConfig([
-      'user',
+      'node',
+      'search_api',
       'localgov_roles',
+      'localgov_directories',
+      'localgov_directories_page',
     ]);
   }
 
@@ -45,9 +71,7 @@ class RolesIntegrationTest extends KernelTestBase {
    * Check default roles applied.
    */
   public function testEnablingRolesModule() {
-    $this->container->get('module_installer')->install([
-      'localgov_directories_page',
-    ]);
+    RolesHelper::assignModuleRoles('localgov_directories_page');
 
     $editor = Role::load(RolesHelper::EDITOR_ROLE);
     $author = Role::load(RolesHelper::AUTHOR_ROLE);

--- a/modules/localgov_directories_promo_page/localgov_directories_promo_page.info.yml
+++ b/modules/localgov_directories_promo_page/localgov_directories_promo_page.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Directories Promo Page'
 type: module
 description: 'Provides a rich unstructured entry type for directory channels.'
 package: LocalGov Drupal
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:link
   - address:address

--- a/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Functional/DirectoryPromoPageTest.php
@@ -21,12 +21,12 @@ class DirectoryPromoPageTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.

--- a/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -21,15 +21,23 @@ class RolesIntegrationTest extends KernelTestBase {
   protected static $modules = [
     'address',
     'block',
+    'entity_reference_revisions',
     'facets',
     'field',
+    'field_formatter_class',
     'field_group',
+    'file',
     'filter',
     'image',
+    'layout_discovery',
+    'layout_paragraphs',
     'link',
     'media',
     'media_library',
+    'menu_ui',
     'node',
+    'options',
+    'paragraphs',
     'path',
     'path_alias',
     'pathauto',
@@ -46,6 +54,8 @@ class RolesIntegrationTest extends KernelTestBase {
     'localgov_roles',
     'localgov_directories',
     'localgov_directories_promo_page',
+    'localgov_paragraphs',
+    'localgov_paragraphs_layout',
   ];
 
   /**
@@ -62,6 +72,7 @@ class RolesIntegrationTest extends KernelTestBase {
       'node',
       'search_api',
       'localgov_roles',
+      'localgov_paragraphs_layout',
       'localgov_directories',
       'localgov_directories_promo_page',
     ]);

--- a/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,17 +19,33 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
-    'system',
-    'user',
+    'address',
+    'block',
+    'facets',
     'field',
+    'field_group',
+    'filter',
+    'image',
+    'link',
+    'media',
+    'media_library',
     'node',
     'path',
+    'path_alias',
+    'pathauto',
     'role_delegation',
+    'search_api',
+    'search_api_db',
     'system',
+    'telephone',
     'text',
+    'token',
     'toolbar',
     'user',
+    'views',
     'localgov_roles',
+    'localgov_directories',
+    'localgov_directories_promo_page',
   ];
 
   /**
@@ -37,9 +53,17 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('search_api_task');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
     $this->installConfig([
-      'user',
+      'node',
+      'search_api',
       'localgov_roles',
+      'localgov_directories',
+      'localgov_directories_promo_page',
     ]);
   }
 
@@ -47,7 +71,7 @@ class RolesIntegrationTest extends KernelTestBase {
    * Check default roles applied.
    */
   public function testEnablingRolesModule() {
-    $this->container->get('module_installer')->install(['localgov_directories_promo_page']);
+    RolesHelper::assignModuleRoles('localgov_directories_promo_page');
 
     $editor = Role::load(RolesHelper::EDITOR_ROLE);
     $author = Role::load(RolesHelper::AUTHOR_ROLE);

--- a/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_promo_page/tests/src/Kernel/RolesIntegrationTest.php
@@ -21,6 +21,14 @@ class RolesIntegrationTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'user',
+    'field',
+    'node',
+    'path',
+    'role_delegation',
+    'system',
+    'text',
+    'toolbar',
+    'user',
     'localgov_roles',
   ];
 
@@ -29,7 +37,10 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->installConfig(['user', 'localgov_roles']);
+    $this->installConfig([
+      'user',
+      'localgov_roles',
+    ]);
   }
 
   /**

--- a/modules/localgov_directories_venue/localgov_directories_venue.info.yml
+++ b/modules/localgov_directories_venue/localgov_directories_venue.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides a standard venue type for directory channels.'
 package: LocalGov Drupal
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - field_group:field_group
   - localgov_directories:localgov_directories

--- a/modules/localgov_directories_venue/localgov_directories_venue.info.yml
+++ b/modules/localgov_directories_venue/localgov_directories_venue.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories Venue'
 type: module
 description: 'Provides a standard venue type for directory channels.'
 package: LocalGov Drupal
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - field_group:field_group

--- a/modules/localgov_directories_venue/tests/src/Functional/DirectoryVenueTest.php
+++ b/modules/localgov_directories_venue/tests/src/Functional/DirectoryVenueTest.php
@@ -21,7 +21,7 @@ class DirectoryVenueTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * Use stark as tests are not dependent on core markup.

--- a/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,17 +19,28 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
-    'system',
-    'user',
+    'address',
+    'block',
+    'facets',
     'field',
+    'filter',
+    'image',
+    'link',
+    'media',
     'node',
     'path',
     'role_delegation',
+    'search_api',
+    'search_api_db',
     'system',
+    'telephone',
     'text',
     'toolbar',
     'user',
+    'views',
     'localgov_roles',
+    'localgov_directories',
+    'localgov_directories_venue',
   ];
 
   /**
@@ -37,9 +48,17 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('search_api_task');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
     $this->installConfig([
-      'user',
+      'node',
+      'search_api',
       'localgov_roles',
+      'localgov_directories',
+      'localgov_directories_venue',
     ]);
   }
 
@@ -47,7 +66,7 @@ class RolesIntegrationTest extends KernelTestBase {
    * Check default roles applied.
    */
   public function testEnablingRolesModule() {
-    $this->container->get('module_installer')->install(['localgov_directories_venue']);
+    RolesHelper::assignModuleRoles('localgov_directories_venue');
 
     $editor = Role::load(RolesHelper::EDITOR_ROLE);
     $author = Role::load(RolesHelper::AUTHOR_ROLE);

--- a/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
@@ -21,6 +21,14 @@ class RolesIntegrationTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'user',
+    'field',
+    'node',
+    'path',
+    'role_delegation',
+    'system',
+    'text',
+    'toolbar',
+    'user',
     'localgov_roles',
   ];
 
@@ -29,7 +37,10 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->installConfig(['user', 'localgov_roles']);
+    $this->installConfig([
+      'user',
+      'localgov_roles',
+    ]);
   }
 
   /**

--- a/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
+++ b/modules/localgov_directories_venue/tests/src/Kernel/RolesIntegrationTest.php
@@ -21,26 +21,34 @@ class RolesIntegrationTest extends KernelTestBase {
   protected static $modules = [
     'address',
     'block',
+    'entity_browser',
     'facets',
     'field',
+    'field_group',
     'filter',
     'image',
     'link',
     'media',
+    'media_library',
     'node',
     'path',
+    'path_alias',
+    'pathauto',
     'role_delegation',
     'search_api',
     'search_api_db',
     'system',
     'telephone',
     'text',
+    'token',
     'toolbar',
     'user',
     'views',
     'localgov_roles',
     'localgov_directories',
+    'localgov_directories_location',
     'localgov_directories_venue',
+    'localgov_geo',
   ];
 
   /**
@@ -52,12 +60,14 @@ class RolesIntegrationTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('search_api_task');
     $this->installEntitySchema('user');
+    $this->installEntitySchema('localgov_geo');
     $this->installSchema('node', ['node_access']);
     $this->installConfig([
       'node',
       'search_api',
       'localgov_roles',
       'localgov_directories',
+      'localgov_directories_location',
       'localgov_directories_venue',
     ]);
   }

--- a/modules/localgov_directories_venue_or/localgov_directories_venue_or.info.yml
+++ b/modules/localgov_directories_venue_or/localgov_directories_venue_or.info.yml
@@ -2,7 +2,6 @@ name: 'LocalGov Directories: Venue - Open Referral'
 type: module
 description: 'EXPERIMENTAL - Make venue directory entries Open Referral services, give existing Venues an Organization.'
 package: LocalGov Drupal (Experimental)
-core: 8.x
 core_version_requirement: ^9 || ^10
 experimental: true
 dependencies:

--- a/modules/localgov_directories_venue_or/localgov_directories_venue_or.info.yml
+++ b/modules/localgov_directories_venue_or/localgov_directories_venue_or.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'EXPERIMENTAL - Make venue directory entries Open Referral services, give existing Venues an Organization.'
 package: LocalGov Drupal (Experimental)
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 experimental: true
 dependencies:
   - localgov_directories:localgov_directories_venue

--- a/src/LocalgovDirectoriesFacetsListBuilder.php
+++ b/src/LocalgovDirectoriesFacetsListBuilder.php
@@ -72,6 +72,7 @@ class LocalgovDirectoriesFacetsListBuilder extends EntityListBuilder {
    */
   protected function getEntityIds() {
     $query = $this->getStorage()->getQuery()
+      ->accessCheck(TRUE)
       ->sort($this->entityType->getKey('bundle'))
       ->sort($this->entityType->getKey('weight'))
       ->sort($this->entityType->getKey('label'));

--- a/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
+++ b/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
@@ -43,7 +43,7 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -26,12 +26,12 @@ class LocalgovIntegrationTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.

--- a/tests/src/Kernel/RolesIntegrationTest.php
+++ b/tests/src/Kernel/RolesIntegrationTest.php
@@ -19,17 +19,27 @@ class RolesIntegrationTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
-    'system',
-    'user',
+    'address',
+    'block',
+    'facets',
     'field',
+    'filter',
+    'image',
+    'link',
+    'media',
     'node',
     'path',
     'role_delegation',
+    'search_api',
+    'search_api_db',
     'system',
+    'telephone',
     'text',
     'toolbar',
     'user',
+    'views',
     'localgov_roles',
+    'localgov_directories',
   ];
 
   /**
@@ -37,9 +47,16 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('search_api_task');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', ['node_access']);
     $this->installConfig([
-      'user',
+      'node',
+      'search_api',
       'localgov_roles',
+      'localgov_directories',
     ]);
   }
 
@@ -47,7 +64,7 @@ class RolesIntegrationTest extends KernelTestBase {
    * Check default roles applied.
    */
   public function testEnablingRolesModule() {
-    $this->container->get('module_installer')->install(['localgov_directories']);
+    RolesHelper::assignModuleRoles('localgov_directories');
 
     $editor = Role::load(RolesHelper::EDITOR_ROLE);
     $author = Role::load(RolesHelper::AUTHOR_ROLE);

--- a/tests/src/Kernel/RolesIntegrationTest.php
+++ b/tests/src/Kernel/RolesIntegrationTest.php
@@ -21,6 +21,14 @@ class RolesIntegrationTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'user',
+    'field',
+    'node',
+    'path',
+    'role_delegation',
+    'system',
+    'text',
+    'toolbar',
+    'user',
     'localgov_roles',
   ];
 
@@ -29,7 +37,10 @@ class RolesIntegrationTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->installConfig(['user', 'localgov_roles']);
+    $this->installConfig([
+      'user',
+      'localgov_roles',
+    ]);
   }
 
   /**


### PR DESCRIPTION
There needs to be a major release of LocalGov Geo fro Drupal support (https://github.com/localgovdrupal/localgov_geo/issues/65#issuecomment-1447093730), which as a dependency of Directories requires a major version bump.

This will require a 3.x release.

Fixes #256 