### PR TITLE
Try to find all the possible sibling facets from a facet group

### DIFF
--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -71,7 +71,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     // Get passed in facets.
     $temp_query = $this->query->getOriginalQuery();
     $temp_query->preExecute();
-    $conditions = &$temp_query->getConditionGroup()->getConditions();
+    $conditions = $temp_query->getConditionGroup()->getConditions();
 
     // Find all the facet condition groups.
     $facet_conditions = [];
@@ -147,7 +147,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     $filter_query->preExecute();
 
     // Find conditions.
-    $conditions = &$filter_query->getConditionGroup()->getConditions();
+    $conditions = $filter_query->getConditionGroup()->getConditions();
 
     // Store removed conditions so we can reset them.
     $removed_conditions = [];
@@ -172,10 +172,8 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     $facets = $filter_query->getResults()->getExtraData('search_api_facets');
     $filter_query->postExecute();
 
-    // Beacuse for reasons unknown, removing the conditions removes it from all
-    // the following queries, even though we are fetching the original query.
-    // We can get around that by readding the conditions back in now that we
-    // have the facets we want.
+    // Without deep cloning we've affected the conditions, reset these for the
+    // query.
     $conditions = array_merge($conditions, $removed_conditions);
 
     // Since we will get every facet from the passed in facet group,

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -66,32 +66,43 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
   public function build() {
     $results = $this->results;
     $query_operator = $this->facet->getQueryOperator();
+    $field_identifier = $this->facet->getFieldIdentifier();
+
+    // Get passed in facets.
     $temp_query = $this->query->getOriginalQuery();
     $temp_query->preExecute();
     $conditions = &$temp_query->getConditionGroup()->getConditions();
+
+    // Find all the facet condition groups.
+    $facet_conditions = [];
     foreach ($conditions as $key => $condition) {
-      if ($condition instanceof \Drupal\search_api\Query\ConditionGroupInterface) {
+      if ($condition instanceof ConditionGroupInterface) {
         $tags = $condition->getTags();
         foreach($tags as $tag) {
-          if (strpos($tag, 'facet:localgov_directory_facets_filter.') === 0) {
-            // unset($conditions[$key]);
-            $results = array_merge($results, $this->getGroupFacets($tag));
+          if (strpos($tag, 'facet:' . $field_identifier . '.') === 0) {
+            $facet_conditions[$key] = $tag;
           }
         }
       }
     }
-    $filtered_results[] = reset($results);
-    foreach ($results as $result) {
-      $current_results = array_column($filtered_results, 'filter');
-      if (!in_array($result['filter'], $current_results)) {
-        $filtered_results[] = $result;
-      }
-    }
-    $results = $filtered_results;
-    // $temp_query->execute();
-    // $avalible_facets = $temp_query->getResults()->getExtraData('search_api_facets');
-    // $results = $avalible_facets['localgov_directory_facets_filter'] ?? $this->results;
 
+    // Run query elimnating each facet group and return the resulting facets.
+    $results = $this->results;
+    foreach($facet_conditions as $key => $filter_tag) {
+      $group_facets = $this->getResultingFacetsFromFacetGroupExceptOwn($filter_tag);
+      
+      // Remove any duplicate facets, or they show up multiple times.
+      $group_facets_filtered = array_filter($group_facets, function($item) use ($results) {
+        $facet_ids = array_column($results, 'filter');
+        if (in_array($item['filter'], $facet_ids)) {
+          return FALSE;
+        }
+        return TRUE;
+      });
+      $results = array_merge($results, $group_facets_filtered);
+    }
+
+    // Build facets.
     if (!empty($results)) {
       $facet_results = [];
       foreach ($results as $result) {
@@ -114,18 +125,78 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     return $this->facet;
   }
 
-  protected function getGroupFacets($filter_tag) {
-    $filter_query = $this->query->getOriginalQuery();
+  /**
+   * Get facets from a facet group except it's own with a corresponding tag
+   * 
+   * Re-run the search api query, this time removing all the other facet groups
+   * except the one specified by the filter tag. The purpose of this is to get
+   * the other facets that would be limited by setting of the passed in groups
+   * facets. It allows us to see the other possible facets that could be 
+   * selected as part of an 'OR' group 'AND' the facets selected in the passed
+   * in group.
+   *
+   * @param String $filter_tag
+   *   The search api tag of the facet group.
+   * @return Array
+   *   Search api query facet results.
+   */
+  protected function getResultingFacetsFromFacetGroupExceptOwn(String $filter_tag):Array {
+
+    // Set up a special filter query which needs to clone the original.
+    $filter_query = clone $this->query->getOriginalQuery();
     $filter_query->preExecute();
+
+    // Find conditions
     $conditions = &$filter_query->getConditionGroup()->getConditions();
+
+    // Store removed conditions so we can reset them.
+    $removed_conditions = [];
+
+    // Loop through each conditions, removing ones that are not this filter tag.
     foreach ($conditions as $tag => $condition) {
-      if ($condition instanceof ConditionGroupInterface && $condition->hasTag($filter_tag)) {
-        unset($conditions[$tag]);
+      if ($condition instanceof ConditionGroupInterface) {
+        $tags = $condition->getTags();
+
+        // @todo Check that we are only removing facet conditions.
+        if (!in_array($filter_tag, $tags)) {
+
+          // Store the removed conditions and remove it.
+          $removed_conditions[$tag] = $conditions[$tag];
+          unset($conditions[$tag]);
+        }
       }
     }
+
+    // Execute the filter query and get the facets returned.
     $filter_query->execute();
     $facets = $filter_query->getResults()->getExtraData('search_api_facets');
-    return $facets['localgov_directory_facets_filter'] ?? [];
+    $filter_query->postExecute();
+
+    // Beacuse for reasons unknown, removing the conditions removes it from all
+    // the following queries, even though we are fetching the original query.
+    // We can get around that by readding the conditions back in now that we 
+    // have the facets we want.
+    $conditions = array_merge($conditions, $removed_conditions);
+
+    // Since we will get every facet from the passed in facet group,
+    // we need to filter those out so checks with other facet groups will
+    // show us only the ones that are reachable from this facet group.
+    $facet_type_id = substr($filter_tag, 39);
+    $group_facet_ids = \Drupal::entityTypeManager()
+      ->getStorage('localgov_directories_facets')
+      ->getQuery()
+      ->condition('bundle', $facet_type_id)
+      ->execute();
+    $found_facets = $facets['localgov_directory_facets_filter'] ?? [];
+    $found_facets = array_filter($found_facets, function($item) use($group_facet_ids) {
+      if (!in_array(intval(trim($item['filter'], '"')), $group_facet_ids)) {
+        return TRUE;
+      }
+      return FALSE;
+    });
+
+    // Finally return the found facets.
+    return $found_facets;
   }
 
 }

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -78,7 +78,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     foreach ($conditions as $key => $condition) {
       if ($condition instanceof ConditionGroupInterface) {
         $tags = $condition->getTags();
-        foreach($tags as $tag) {
+        foreach ($tags as $tag) {
           if (strpos($tag, 'facet:' . $field_identifier . '.') === 0) {
             $facet_conditions[$key] = $tag;
           }
@@ -87,12 +87,11 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     }
 
     // Run query elimnating each facet group and return the resulting facets.
-    $results = $this->results;
-    foreach($facet_conditions as $key => $filter_tag) {
+    foreach ($facet_conditions as $key => $filter_tag) {
       $group_facets = $this->getResultingFacetsFromFacetGroupExceptOwn($filter_tag);
-      
+
       // Remove any duplicate facets, or they show up multiple times.
-      $group_facets_filtered = array_filter($group_facets, function($item) use ($results) {
+      $group_facets_filtered = array_filter($group_facets, function ($item) use ($results) {
         $facet_ids = array_column($results, 'filter');
         if (in_array($item['filter'], $facet_ids)) {
           return FALSE;
@@ -126,27 +125,28 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
   }
 
   /**
-   * Get facets from a facet group except it's own with a corresponding tag
-   * 
+   * Get facets from a facet group except it's own with a corresponding tag.
+   *
    * Re-run the search api query, this time removing all the other facet groups
    * except the one specified by the filter tag. The purpose of this is to get
    * the other facets that would be limited by setting of the passed in groups
-   * facets. It allows us to see the other possible facets that could be 
+   * facets. It allows us to see the other possible facets that could be
    * selected as part of an 'OR' group 'AND' the facets selected in the passed
    * in group.
    *
-   * @param String $filter_tag
+   * @param string $filter_tag
    *   The search api tag of the facet group.
-   * @return Array
+   *
+   * @return array
    *   Search api query facet results.
    */
-  protected function getResultingFacetsFromFacetGroupExceptOwn(String $filter_tag):Array {
+  protected function getResultingFacetsFromFacetGroupExceptOwn(string $filter_tag): array {
 
     // Set up a special filter query which needs to clone the original.
     $filter_query = clone $this->query->getOriginalQuery();
     $filter_query->preExecute();
 
-    // Find conditions
+    // Find conditions.
     $conditions = &$filter_query->getConditionGroup()->getConditions();
 
     // Store removed conditions so we can reset them.
@@ -174,7 +174,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
 
     // Beacuse for reasons unknown, removing the conditions removes it from all
     // the following queries, even though we are fetching the original query.
-    // We can get around that by readding the conditions back in now that we 
+    // We can get around that by readding the conditions back in now that we
     // have the facets we want.
     $conditions = array_merge($conditions, $removed_conditions);
 
@@ -188,7 +188,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
       ->condition('bundle', $facet_type_id)
       ->execute();
     $found_facets = $facets['localgov_directory_facets_filter'] ?? [];
-    $found_facets = array_filter($found_facets, function($item) use($group_facet_ids) {
+    $found_facets = array_filter($found_facets, function ($item) use ($group_facet_ids) {
       if (!in_array(intval(trim($item['filter'], '"')), $group_facet_ids)) {
         return TRUE;
       }

--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -143,8 +143,11 @@ class FacetsTest extends BrowserTestBase {
 
   /**
    * Test facets filter with And groups.
+   *
+   * Verifies that the correct entries are visible using an OR filter within
+   * facet groups and a AND filter accross the groups.
    */
-  public function testFacetsFilters() {
+  public function testFacetsGroupFilters() {
 
     // Set up some directory entires.
     $directory_nodes = [
@@ -359,7 +362,7 @@ class FacetsTest extends BrowserTestBase {
         ],
       ],
       [
-        // Entry 3 has facet 2 only
+        // Entry 3 has facet 2 only.
         'title' => 'Entry 3 ' . $this->randomMachineName(8),
         'type' => 'localgov_directories_page',
         'body' => [
@@ -404,9 +407,6 @@ class FacetsTest extends BrowserTestBase {
     foreach ($directory_nodes as $node) {
       $this->createNode($node);
     }
-
-    // Get titles for comparison.
-    $node_titles = array_column($directory_nodes, 'title');
 
     // Run cron so the directory entires are indexed.
     $this->cronRun();


### PR DESCRIPTION
To try and resolve this comment 
  https://github.com/localgovdrupal/localgov_directories/pull/235#issuecomment-1277842772

Adds a filter for the facets to try and get the sibling versions so possible OR facets are avalible if the other groups set an AND.

This works well for two facets groups, though more does lead to more 0 result possiblilties.