### PR TITLE
Adds proximity search option and functionality to channels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,36 @@ export the facet types set:
 and it will be exported with other configuration. Any types that exist in
 configuration will be imported.
 
+### Proximity search
+
+Proximity search is made available when:
+- The Directory search backend supports location search.  At the moment the *search_api_solr* search backend from the [search_api_solr module](https://www.drupal.org/project/search_api_solr) is the only such known backend.
+- At least one of the available Directory entry content types (e.g. localgov_directories_venue) is using location through the
+localgov_location field.
+
+When location search is available, a new "Proximity search settings" choice field becomes available in Directory channel forms.  Activating this will present a Proximity search filter as part of the channel search form.
+
+The Proximity search filter uses the following distances out-of-the-box: 1km for 1/2 mile, 2km for 1 mile, 3km for 2 miles, 5km for 3 miles, 8km for 5 miles, and 16km for 10 miles.  These mappings are not exact.  This is due to Solr's insistence on using round Kilometer values during location-based filtering.  To update these distance values, edit the Proximity filter's settings in the *Directory channel* view's *Embed: Proximity search* and *Embed map* displays.
+
+#### Supported database backends
+The [dev release of the search_api module](https://www.drupal.org/project/search_api/releases/8.x-1.x-dev) now supports location-based search in database search backends.  Supported database versions are:
+- MySQL 5.7 and later.
+- MariaDB 10.2.38, 10.3.29, 10.4.19, 10.5.10 and later.
+
 ## Block placement
 
-When using a theme other than the default LocalGov theme, the
-**Directory channel search** (machine id: localgov_directories_channel_search_block)
-and **Directory facets** (machine id: facet_block:localgov_directories_facets)
+When using a theme other than the default LocalGov Base or LocalGov Scarfolk, the
+**Directory channel search** (machine id: localgov_directories_channel_search_block),
+**Directory facets** (machine id: facet_block:localgov_directories_facets) and
+**Directory facets for proximity search** (machine id: facet_block:localgov_directories_facets_proximity_search)
 blocks should be made visible for the **Directory Channel** content type.
-They can be added to a sidebar region (or equivalent) of the site theme.  Note
-that the facet_block:localgov_directories_facets block becomes available only
-after you have created at least one Directory entry content type.
+They can be added to a sidebar region (or equivalent) of the site theme.
+
+Note that the facet_block:localgov_directories_facets block becomes available only
+after you have created at least one Directory entry content type.  On the other
+hand the facet_block:localgov_directories_facets_proximity_search block becomes
+available when a Directory entry content type with a localgov_location field is
+created (e.g. localgov_directories_venue).
 
 On the Directory entry content types the blocks are also available as 'fields'
 in the Fields display configuration if you prefer to place them within the

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
     "require": {
         "drupal/facets": "^2.0",
         "drupal/pathauto": "^1.6",
-        "drupal/search_api": "^1.17",
+        "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.3",
+        "drupal/search_api_location": "1.x-dev",
         "localgovdrupal/localgov_core": "^2.1",
         "localgovdrupal/localgov_geo": "^1.1"
     },

--- a/config/conditional/README.md
+++ b/config/conditional/README.md
@@ -2,4 +2,5 @@
 This is **not** a standard location for Drupal's config files.  As such these config files will not be imported at module install time.  Instead config files in this directory are added programmatically.
 
 ## Config files
-- facets.facet.localgov_directories_facets.yml: Added when the **localgov_directory_facets_select** Facet selection field is added to a Directory entry content type for the first time. @see localgov_directories_create_dir_facet()
+- facets.facet.localgov_directories_facets.yml: Added when the **localgov_directory_facets_select** Facet selection field is added to a Directory entry content type for the first time. @see localgov_directories_field_config_insert()
+- facets.facet.localgov_directories_facets_proximity_search.yml: Added when Proximity search display of the localgov_directory_channel View is added. @see localgov_directories_location_field_config_insert()

--- a/config/conditional/facets.facet.localgov_directories_facets_proximity_search.yml
+++ b/config/conditional/facets.facet.localgov_directories_facets_proximity_search.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.localgov_directories_index_default
+    - views.view.localgov_directory_channel
+  module:
+    - search_api
+id: localgov_directories_facets_proximity_search
+name: Facets for proximity search
+url_alias: localgov_directories_facets
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: localgov_directory_facets_filter
+facet_source_id: 'search_api:views_embed__localgov_directory_channel__node_embed_for_proximity_search'
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: false
+processor_configs:
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+  weight_property_order:
+    processor_id: weight_property_order
+    weights:
+      sort: -5
+    settings:
+      sort: ASC
+empty_behavior:
+  behavior: none
+show_title: false

--- a/config/optional/block.block.localgov_directories_facets_proximity_search.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.localgov_directories_facets_proximity_search
+  module:
+    - facets
+    - node
+  theme:
+    - localgov_base
+id: localgov_directories_facets_proximity_search
+theme: localgov_base
+region: sidebar_first
+weight: 5
+provider: null
+plugin: 'facet_block:localgov_directories_facets_proximity_search'
+settings:
+  id: 'facet_block:localgov_directories_facets_proximity_search'
+  label: 'Directory facets for proximity search'
+  provider: facets
+  label_display: '0'
+  block_id: localgov_directories_facets_proximity_search
+visibility:
+  node_type:
+    id: node_type
+    bundles:
+      localgov_directory: localgov_directory
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.localgov_directories_facets_proximity_search
+  module:
+    - facets
+    - node
+  theme:
+    - localgov_scarfolk
+id: localgov_directories_facets_proximity_search_scarfolk
+theme: localgov_scarfolk
+region: sidebar_first
+weight: 5
+provider: null
+plugin: 'facet_block:localgov_directories_facets_proximity_search'
+settings:
+  id: 'facet_block:localgov_directories_facets_proximity_search'
+  label: 'Directory facets for proximity search'
+  provider: facets
+  label_display: '0'
+  block_id: localgov_directories_facets_proximity_search
+visibility:
+  node_type:
+    id: node_type
+    bundles:
+      localgov_directory: localgov_directory
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/modules/localgov_directories_location/config/conditional/field.field.node.localgov_directory.localgov_proximity_search_cfg.yml
+++ b/modules/localgov_directories_location/config/conditional/field.field.node.localgov_directory.localgov_proximity_search_cfg.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_proximity_search_cfg
+    - node.type.localgov_directory
+id: node.localgov_directory.localgov_proximity_search_cfg
+field_name: localgov_proximity_search_cfg
+entity_type: node
+bundle: localgov_directory
+label: 'Proximity search settings'
+description: 'Activate proximity search for directory entries.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/localgov_directories_location/config/install/field.storage.node.localgov_proximity_search_cfg.yml
+++ b/modules/localgov_directories_location/config/install/field.storage.node.localgov_proximity_search_cfg.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.localgov_proximity_search_cfg
+field_name: localgov_proximity_search_cfg
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_directories_location/config/override/core.entity_form_display.node.localgov_directory.default.yml
+++ b/modules/localgov_directories_location/config/override/core.entity_form_display.node.localgov_directory.default.yml
@@ -1,0 +1,98 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
+    - field.field.node.localgov_directory.localgov_directory_channel_types
+    - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - node.type.localgov_directory
+  module:
+    - path
+    - text
+id: node.localgov_directory.default
+targetEntityType: node
+bundle: localgov_directory
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: true
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  localgov_proximity_search_cfg:
+    type: boolean_checkbox
+    weight: 124
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  localgov_directory_channel_types:
+    weight: 123
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  localgov_directory_facets_enable:
+    weight: 122
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
+++ b/modules/localgov_directories_location/config/override/views.view.localgov_directory_channel.yml
@@ -3,12 +3,15 @@ status: true
 dependencies:
   config:
     - field.storage.localgov_geo.location
+    - field.storage.node.body
     - search_api.index.localgov_directories_index_default
   module:
     - geofield
     - leaflet_views
     - localgov_geo
     - search_api
+    - search_api_location_views
+    - text
 id: localgov_directory_channel
 label: 'Directory channel'
 module: views
@@ -475,6 +478,118 @@ display:
         options:
           offset: 0
       empty: {  }
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_localgov_directories_index_default
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+        localgov_location:
+          id: localgov_location
+          table: search_api_index_localgov_directories_index_default
+          field: localgov_location
+          relationship: none
+          group_type: group
+          admin_label: Proximity
+          plugin_id: search_api_location
+          operator: '<'
+          value:
+            distance:
+              from: '-'
+              to: '-'
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: localgov_location_op
+            label: Location
+            description: ''
+            use_operator: false
+            operator: localgov_location_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: localgov_location
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin: geocode
+          plugin-raw:
+            radius_type: select
+            radius_options: "- -\r\n1 1/2 mile\r\n2 1 mile\r\n3 2 miles\r\n5 3 miles\r\n8 5 miles\r\n16 10 miles"
+            radius_units: km
+          plugin-geocode_map:
+            radius_border_color: ''
+            radius_border_weight: ''
+            radius_background_color: ''
+            radius_background_transparency: ''
+            marker_image: ''
+          plugin-geocode:
+            plugins:
+              localgov_default_osm:
+                checked: '1'
+                weight: '0'
+            radius_type: select
+            radius_options: "- -\r\n1 1/2 mile\r\n2 1 mile\r\n3 2 miles\r\n5 3 miles\r\n8 5 miles\r\n16 10 miles"
+            radius_units: km
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: leaflet_map
         options:
@@ -568,6 +683,8 @@ display:
         row: false
         relationships: false
         fields: false
+        filters: false
+        filter_groups: false
       relationships:
         localgov_location:
           id: localgov_location
@@ -611,4 +728,405 @@ display:
         - url.query_args
         - 'user.node_grants:view'
       tags:
+        - 'config:search_api.index.localgov_directories_index_default'
+  node_embed_for_proximity_search:
+    id: node_embed_for_proximity_search
+    display_title: 'Embed: Proximity search'
+    display_plugin: embed
+    position: 1
+    display_options:
+      fields:
+        title:
+          id: title
+          table: search_api_datasource_localgov_directories_index_default_entity_node
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: true
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        body:
+          id: body
+          table: search_api_datasource_localgov_directories_index_default_entity_node
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        localgov_location_distance:
+          id: localgov_location_distance
+          table: search_api_index_localgov_directories_index_default
+          field: localgov_location_distance
+          relationship: none
+          group_type: group
+          admin_label: Proximity
+          plugin_id: search_api_numeric
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ (localgov_location_distance / 1.609) | round(1) }} miles'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary Aw==
+          prefix: ''
+          suffix: ''
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          format_plural_values: {  }
+      cache:
+        type: none
+      sorts:
+        localgov_location_distance:
+          id: localgov_location_distance
+          table: search_api_index_localgov_directories_index_default
+          field: localgov_location_distance
+          relationship: none
+          group_type: group
+          admin_label: Proximity
+          plugin_id: search_api_location_distance
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_localgov_directories_index_default
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: search_api_relevance
+          exposed: false
+        localgov_directory_title_sort:
+          id: localgov_directory_title_sort
+          table: search_api_index_localgov_directories_index_default
+          field: localgov_directory_title_sort
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: localgov_directory_title_sort
+          exposed: false
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_localgov_directories_index_default
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+        localgov_location:
+          id: localgov_location
+          table: search_api_index_localgov_directories_index_default
+          field: localgov_location
+          relationship: none
+          group_type: group
+          admin_label: Proximity
+          plugin_id: search_api_location
+          operator: '<'
+          value:
+            distance:
+              from: '-'
+              to: '-'
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: localgov_location_op
+            label: Location
+            description: 'Proximity from a given location.'
+            use_operator: false
+            operator: localgov_location_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: localgov_location
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin: geocode
+          plugin-raw:
+            radius_type: select
+            radius_options: "- -\r\n1 1/2 mile\r\n2 1 mile\r\n3 2 miles\r\n5 3 miles\r\n8 5 miles\r\n16 10 miles"
+            radius_units: km
+          plugin-geocode_map:
+            radius_border_color: ''
+            radius_border_weight: ''
+            radius_background_color: ''
+            radius_background_transparency: ''
+            marker_image: ''
+          plugin-geocode:
+            plugins:
+              localgov_default_osm:
+                checked: '1'
+                weight: '0'
+            radius_type: select
+            radius_options: "- -\r\n1 1/2 mile\r\n2 1 mile\r\n3 2 miles\r\n5 3 miles\r\n8 5 miles\r\n16 10 miles"
+            radius_units: km
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        cache: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+      display_description: 'Proximity search for Directory entries'
+      display_comment: 'Solr''s distance calculation uses Kilometer as the unit by default.  The "Proximity" field uses the "Rewrite results" settings to display such distances in miles.  1 Mile is 1609 meter.'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.body'
         - 'config:search_api.index.localgov_directories_index_default'

--- a/modules/localgov_directories_location/localgov_directories_location.info.yml
+++ b/modules/localgov_directories_location/localgov_directories_location.info.yml
@@ -9,3 +9,5 @@ dependencies:
   - localgov_directories:localgov_directories
   - localgov_geo:localgov_geo_address
   - leaflet:leaflet_views
+  - search_api_location:search_api_location_views
+  - search_api_location:search_api_location_geocoder

--- a/modules/localgov_directories_location/localgov_directories_location.install
+++ b/modules/localgov_directories_location/localgov_directories_location.install
@@ -6,13 +6,26 @@
  */
 
 use Drupal\Component\Serialization\Yaml;
+use Drupal\localgov_directories\Constants as Directory;
 use Drupal\views\Entity\View;
+use Drupal\localgov_directories_location\ProximitySearchSetup;
 
 /**
  * Implements hook_install().
+ *
+ * - Adds location field to search index.
+ * - Adds extra displays to the Directory channel view.
+ * - Adds the Proximity search configuration field to the Directory channel
+ *   form.  Also hides it from entity view.
  */
-function localgov_directories_location_install() {
-  // Retrieve view display mode config and add it to the existing configuration.
+function localgov_directories_location_install($is_syncing) {
+
+  if ($is_syncing) {
+    return;
+  }
+
+  // Retrieves view display mode config and adds location-related sections to
+  // the existing configuration.
   $module_path = \Drupal::service('extension.list.module')->getPath('localgov_directories_location');
   $view_with_map_embed = Yaml::decode(file_get_contents($module_path . '/config/override/views.view.localgov_directory_channel.yml'));
   $view = View::load('localgov_directory_channel');
@@ -52,4 +65,28 @@ function localgov_directories_location_update_8001() {
       ->load('node.localgov_directory.' . $display_id);
     $directory_display->removeComponent('localgov_directory_map')->save();
   }
+}
+
+/**
+ * Sets up proximity search.
+ */
+function localgov_directories_location_update_8003() {
+
+  $proximity_search_setup = \Drupal::classResolver(ProximitySearchSetup::class);
+  if (!$proximity_search_setup->hasLocationSearch()) {
+    return t('Search index is not ready for location search.');
+  }
+
+  Drupal::service('module_installer')->install([
+    'search_api_location_views',
+    'search_api_location_geocoder',
+  ]);
+
+  $location_field_configs = \Drupal::service('entity_type.manager')
+    ->getStorage('field_config')
+    ->loadByProperties([
+      'field_name'  => Directory::LOCATION_FIELD,
+      'entity_type' => 'node',
+    ]);
+  array_walk($location_field_configs, 'localgov_directories_location_field_config_insert');
 }

--- a/modules/localgov_directories_location/localgov_directories_location.module
+++ b/modules/localgov_directories_location/localgov_directories_location.module
@@ -5,9 +5,15 @@
  * Provides a location extension to directories.
  */
 
-use Drupal\localgov_directories_location\LocationExtraFieldDisplay;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\localgov_directories\ConfigurationHelper;
+use Drupal\localgov_directories\Constants as Directory;
+use Drupal\localgov_directories_location\LocationExtraFieldDisplay;
+use Drupal\localgov_directories_location\ProximitySearchSetup;
 use Drupal\node\NodeInterface;
+use Drupal\search_api\Entity\Index as SearchIndex;
+use Drupal\search_api\IndexInterface as SearchIndexInterface;
 
 /**
  * Implements hook_entity_extra_field_info().
@@ -25,4 +31,80 @@ function localgov_directories_location_node_view(array &$build, NodeInterface $n
   return \Drupal::service('class_resolver')
     ->getInstanceFromDefinition(LocationExtraFieldDisplay::class)
     ->nodeView($build, $node, $display, $view_mode);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ *
+ * Once the localgov_location field is available, we need to add it to the
+ * Directories search index and also enable the Proximity search display of the
+ * Directory channel View.
+ *
+ * In a fresh installation of localgov_directories, saving the search index
+ * drops the localgov_directory_channels and localgov_directory_title_sort
+ * fields from the index as they are not attached to any content type yet.  So
+ * we add them again as we are now certain that they are attached to a content
+ * type.
+ */
+function localgov_directories_location_field_config_insert(FieldConfigInterface $field) {
+
+  $proximity_search_setup = \Drupal::classResolver(ProximitySearchSetup::class);
+  if (!$proximity_search_setup->hasLocationSearch()) {
+    return;
+  }
+
+  $index = SearchIndex::load(Directory::DEFAULT_INDEX);
+  $new_field_name = $field->getName();
+  $is_node_entity_type = $field->getTargetEntityTypeId() === 'node';
+
+  if ($new_field_name === Directory::LOCATION_FIELD && $is_node_entity_type && $index && $index->status() && !$index->getField(Directory::LOCATION_FIELD)) {
+    if ($proximity_search_setup->setup($field, $index)) {
+      \Drupal::classResolver(ConfigurationHelper::class)->createFacet(Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH, Directory::FACET_CONFIG_FILE_FOR_PROXIMITY_SEARCH);
+    }
+  }
+  elseif (in_array($new_field_name, [
+    Directory::CHANNEL_SELECTION_FIELD,
+    Directory::TITLE_SORT_FIELD,
+  ]) && $is_node_entity_type && $index) {
+    // The channel selection and title sort fields may have gone missing from
+    // the search index when we added localgov_location.
+    $proximity_search_setup->repairSearchIndex($index);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update() for hook_search_api_index_update().
+ *
+ * Whenever the Directory search index is updated, check if we need to setup
+ * proximity search.  This is useful where location search was unavailable when
+ * this module was installed but has now become available.
+ */
+function localgov_directories_location_search_api_index_update(SearchIndexInterface $search_index) {
+
+  $has_proximity_search_setup_ended = &drupal_static(__FUNCTION__);
+  if (isset($has_proximity_search_setup_ended)) {
+    return;
+  }
+  $has_proximity_search_setup_ended = TRUE;
+
+  if ($search_index->id() !== Directory::DEFAULT_INDEX) {
+    return;
+  }
+
+  if ($search_index->getField(Directory::LOCATION_FIELD)) {
+    return;
+  }
+
+  $proximity_search_setup = \Drupal::classResolver(ProximitySearchSetup::class);
+  if (!$proximity_search_setup->hasLocationSearch()) {
+    return;
+  }
+
+  $location_field_configs = \Drupal::service('entity_type.manager')
+    ->getStorage('field_config')
+    ->loadByProperties([
+      'field_name'  => Directory::LOCATION_FIELD,
+      'entity_type' => 'node',
+    ]);
+  array_walk($location_field_configs, 'localgov_directories_location_field_config_insert');
 }

--- a/modules/localgov_directories_location/src/ProximitySearchSetup.php
+++ b/modules/localgov_directories_location/src/ProximitySearchSetup.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\localgov_directories_location;
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\field\FieldConfigInterface;
+use Drupal\localgov_directories\Constants as Directory;
+use Drupal\search_api\IndexInterface as SearchIndexInterface;
+use Drupal\search_api\Item\Field as SearchIndexField;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Proximity search configuration operations.
+ *
+ * Proximity search setup operations are:
+ * - Add the localgov_location field to the Directory search index.
+ * - Add the Proximity search activation field to the Directory channel content
+ *   type.
+ * - Add a new display for Proximity search to the Directory channel listing
+ *   view.
+ * - If necessary, restore the Directory channel selection field and the
+ *   Directory title sort field to the Directory search index.
+ */
+class ProximitySearchSetup implements ContainerInjectionInterface {
+
+  /**
+   * Carry out all the operations.
+   */
+  public function setup(FieldConfigInterface $field, SearchIndexInterface $index): bool {
+
+    if (!$this->hasLocationSearch($index->id())) {
+      return FALSE;
+    }
+
+    $field_name = $field->getName();
+    $is_node_entity_type = $field->getTargetEntityTypeId() === 'node';
+    if ($field_name !== Directory::LOCATION_FIELD || !$is_node_entity_type || $index->getField(Directory::LOCATION_FIELD)) {
+      return FALSE;
+    }
+
+    if ($this->setupLocationSearch($field, $index)) {
+      // Now that the location field is part of the Directories search index, we
+      // can add it to the Directory channel view.
+      $this->addViewsDisplay();
+
+      $this->addActivationField();
+
+      // The channel selection and title sort fields may have gone missing.
+      $this->repairSearchIndex($index);
+    }
+    else {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Sets up indexing for location field.
+   *
+   * Adds the localgov_location field to the Directories search index.
+   */
+  public function setupLocationSearch(FieldConfigInterface $field, SearchIndexInterface $index): bool {
+
+    if ($index->getField(Directory::LOCATION_FIELD)) {
+      return FALSE;
+    }
+
+    $index_datasrc = $index->getDatasource('entity:node');
+    if (empty($index_datasrc)) {
+      return FALSE;
+    }
+
+    $entity_bundle = $field->getTargetBundle();
+    $datasrc_cfg = $index_datasrc->getConfiguration();
+    $is_bundle_indexed = in_array($entity_bundle, $datasrc_cfg['bundles']['selected']);
+    if (!$is_bundle_indexed) {
+      $datasrc_cfg['bundles']['selected'][] = $entity_bundle;
+      $index_datasrc->setConfiguration($datasrc_cfg);
+    }
+
+    $location_field = new SearchIndexField($index, Directory::LOCATION_FIELD);
+    $location_field->setLabel('Location » Geo » location');
+    $location_field->setDatasourceId('entity:node');
+    $location_field->setType('location');
+    $location_field->setPropertyPath('localgov_location:entity:location');
+    $index->addField($location_field);
+    $index->save();
+    $index->reindex();
+
+    return TRUE;
+  }
+
+  /**
+   * Adds the Proximity search activation field to the Directory channel.
+   *
+   * Also places this field in the Directory channel's form display.
+   */
+  public function addActivationField(): void {
+
+    if (!$this->etm->getStorage('field_storage_config')->load('node' . '.' . Directory::PROXIMITY_SEARCH_CFG_FIELD)) {
+      $proximity_search_cfg_field_storage = Yaml::decode(file_get_contents($this->modulePath . '/config/install/field.storage.node.localgov_proximity_search_cfg.yml'));
+      $this->etm->getStorage('field_storage_config')->create($proximity_search_cfg_field_storage)->save();
+    }
+
+    if (!$this->etm->getStorage('field_config')->load('node' . '.' . Directory::CHANNEL_NODE_BUNDLE . '.' . Directory::PROXIMITY_SEARCH_CFG_FIELD)) {
+      $proximity_search_cfg_field = Yaml::decode(file_get_contents($this->modulePath . '/config/conditional/field.field.node.localgov_directory.localgov_proximity_search_cfg.yml'));
+      $this->etm->getStorage('field_config')->create($proximity_search_cfg_field)->save();
+
+      $this->addActivationFieldDisplay();
+    }
+  }
+
+  /**
+   * Sets up display for the proximity config field.
+   *
+   * - Adds the Proximity search config field to the Directory channel form.
+   * - Hides it from Directory channel entity view.
+   */
+  public function addActivationFieldDisplay(): void {
+
+    // Add Proximity search activation field to Directory channel form.
+    $dir_channel_form_display = $this->etm->getStorage('entity_form_display')->load('node' . '.' . Directory::CHANNEL_NODE_BUNDLE . '.default');
+    if (!$dir_channel_form_display->getComponent(Directory::PROXIMITY_SEARCH_CFG_FIELD)) {
+      $dir_channel_form_display_with_proximity_search = Yaml::decode(file_get_contents($this->modulePath . '/config/override/core.entity_form_display.node.localgov_directory.default.yml'));
+
+      if (isset($dir_channel_form_display_with_proximity_search['content'][Directory::PROXIMITY_SEARCH_CFG_FIELD])) {
+        $dir_channel_form_display->setComponent(Directory::PROXIMITY_SEARCH_CFG_FIELD, $dir_channel_form_display_with_proximity_search['content'][Directory::PROXIMITY_SEARCH_CFG_FIELD])->save();
+      }
+    }
+
+    // Hide the Proximity search activation field from Directory channel.
+    $dir_channel_view_display = $this->etm->getStorage('entity_view_display')->load('node' . '.' . Directory::CHANNEL_NODE_BUNDLE . '.default');
+    if (!$dir_channel_view_display->getComponent(Directory::PROXIMITY_SEARCH_CFG_FIELD)) {
+      $dir_channel_view_display->removeComponent(Directory::PROXIMITY_SEARCH_CFG_FIELD)->save();
+    }
+  }
+
+  /**
+   * Adds the Proximity search display to the Directory channel view.
+   *
+   * Also adds the Proximity search filter to the existing Map display of this
+   * view.
+   */
+  public function addViewsDisplay(): void {
+
+    $view = $this->etm->getStorage('view')->load(Directory::CHANNEL_VIEW);
+    if (empty($view) || $view->getDisplay(Directory::CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY)) {
+      return;
+    }
+
+    $view_with_proximity_search = Yaml::decode(file_get_contents($this->modulePath . '/config/override/views.view.localgov_directory_channel.yml'));
+
+    $displays = $view->get('display');
+    $displays[Directory::CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY] = $view_with_proximity_search['display'][Directory::CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY];
+    $displays[Directory::CHANNEL_VIEW_MAP_DISPLAY] = $view_with_proximity_search['display'][Directory::CHANNEL_VIEW_MAP_DISPLAY];
+    $view->set('display', $displays);
+    $view->save();
+  }
+
+  /**
+   * Restores missing search index fields.
+   *
+   * If needed, adds the channel selection and the title sort fields to the
+   * search index.  These fields may have gone missing from the Directory search
+   * index when the index was updated while these fields were *not* attached to
+   * any indexed node bundle.
+   */
+  public function repairSearchIndex(SearchIndexInterface $index): void {
+
+    if (!$index->getField(Directory::CHANNEL_SELECTION_FIELD)) {
+      $channel_field = new SearchIndexField($index, Directory::CHANNEL_SELECTION_FIELD);
+      $channel_field->setLabel('Directory channels');
+      $channel_field->setDatasourceId('entity:node');
+      $channel_field->setType('integer');
+      $channel_field->setPropertyPath(Directory::CHANNEL_SELECTION_FIELD);
+      $index->addField($channel_field);
+      $index->save();
+      $index->reindex();
+    }
+
+    if (!$index->getField(Directory::TITLE_SORT_FIELD)) {
+      $sort_title_field = new SearchIndexField($index, Directory::TITLE_SORT_FIELD);
+      $sort_title_field->setLabel('Title (sort)');
+      $sort_title_field->setDatasourceId('entity:node');
+      $sort_title_field->setType('string');
+      $sort_title_field->setPropertyPath(Directory::TITLE_SORT_FIELD);
+      $index->addField($sort_title_field);
+      $index->save();
+      $index->reindex();
+    }
+  }
+
+  /**
+   * Is the Search index ready for location search?
+   *
+   * Criteria for readiness:
+   * - Search index is in "enabled" state.
+   * - Search backend of the search index supports location search.
+   */
+  public function hasLocationSearch(string $search_index_name = Directory::DEFAULT_INDEX): bool {
+
+    $search_index = $this->etm->getStorage('search_api_index')->load($search_index_name);
+    if (empty($search_index) || !$search_index->status()) {
+      return FALSE;
+    }
+
+    $search_server = $search_index->getServerInstance();
+    $has_location_search = $search_server ? $search_server->supportsDataType(Directory::SEARCH_API_LOCATION_DATATYPE) : FALSE;
+
+    return $has_location_search;
+  }
+
+  /**
+   * Factory method.
+   */
+  public static function create(ContainerInterface $container) {
+
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('extension.list.module'),
+    );
+  }
+
+  /**
+   * Initializes dependencies.
+   */
+  public function __construct(EntityTypeManagerInterface $etm, ModuleExtensionList $module_ext_list) {
+
+    $this->etm = $etm;
+    $this->modulePath = $module_ext_list->getPath(Directory::LOCATION_MODULE);
+  }
+
+  /**
+   * Entity type manager service.
+   *
+   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $etm;
+
+  /**
+   * Path of this module relative to docroot.
+   *
+   * @var string
+   */
+  protected string $modulePath = '';
+
+}

--- a/modules/localgov_directories_venue/tests/src/Kernel/ViewUpgradeForProximitySearchTest.php
+++ b/modules/localgov_directories_venue/tests/src/Kernel/ViewUpgradeForProximitySearchTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\localgov_directories_venue\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\localgov_directories\Constants as Directory;
+use Drupal\search_api\Entity\Index as SearchIndex;
+use Drupal\views\Views;
+
+/**
+ * Tests additions to the localgov_directory_channel_view.
+ *
+ * The proximity search support is added to the localgov_directory_channel_view
+ * when any new content type with the localgov_location field (e.g.
+ * localgov_directories_venue) is installed.
+ */
+class ViewUpgradeForProximitySearchTest extends KernelTestBase {
+
+  /**
+   * Tests directory channel view modification.
+   *
+   * When the localgov_directories_venue module is installed:
+   * - A new display is added to the view to support proximity search.
+   * - A new facet that uses this new display as a facet source is also added.
+   * Here we verify the existence of the new display and the facet.
+   */
+  public function testViewUpgrade(): void {
+
+    $has_location_search = SearchIndex::load(Directory::DEFAULT_INDEX)
+      ->getServerInstance()
+      ->supportsDataType(Directory::SEARCH_API_LOCATION_DATATYPE);
+    if (!$has_location_search) {
+      $this->markTestSkipped('Database lacks location search feature.');
+      return;
+    }
+
+    $view = Views::getView(Directory::CHANNEL_VIEW);
+    $view->setDisplay(Directory::CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY);
+    $display_for_proximity_search = $view->getDisplay();
+    $has_proximity_search_display = !empty($display_for_proximity_search);
+    $this->assertTrue($has_proximity_search_display);
+
+    $filters = $display_for_proximity_search->getOption('filters');
+    $has_location_filter = array_key_exists('localgov_location', $filters);
+    $this->assertTrue($has_location_filter);
+
+    $facet_for_proximity_search = \Drupal::service('entity_type.manager')->getStorage('facets_facet')->load('localgov_directories_facets_proximity_search');
+    $has_facet_for_proximity_search = !empty($facet_for_proximity_search);
+    $this->assertTrue($has_facet_for_proximity_search);
+  }
+
+  /**
+   * Sets up location search for venues.
+   *
+   * - Activates the Directory search index.
+   * - Enables localgov_directories_venue module.
+   * - Adds the localgov_location field to the search index.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installSchema('search_api', ['search_api_item']);
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('search_api_task');
+
+    $this->installConfig([
+      'node',
+      'search_api',
+      'localgov_directories',
+      'localgov_directories_db',
+    ]);
+
+    // Enable the Directory search index.
+    $localgov_directories_db_module_path = $this->container->get('extension.list.module')->getPath('localgov_directories_db');
+    require_once "$localgov_directories_db_module_path/localgov_directories_db.install";
+    localgov_directories_db_install(FALSE);
+
+    // Now that the search index is available, we are ready to add the
+    // localgov_location field to this index.  So let's import it.
+    // @see localgov_directories_location_field_config_insert().
+    $this->installConfig([
+      'localgov_directories_location',
+      'localgov_directories_venue',
+    ]);
+  }
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'address',
+    'block',
+    'entity_browser',
+    'facets',
+    'field',
+    'field_group',
+    'geofield',
+    'image',
+    'leaflet',
+    'leaflet_views',
+    'link',
+    'localgov_directories',
+    'localgov_directories_db',
+    'localgov_directories_location',
+    'localgov_directories_venue',
+    'localgov_geo',
+    'media',
+    'media_library',
+    'node',
+    'path_alias',
+    'pathauto',
+    'search_api',
+    'search_api_db',
+    'search_api_location_views',
+    'system',
+    'telephone',
+    'text',
+    'token',
+    'user',
+    'views',
+  ];
+
+}

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -187,7 +187,10 @@ class ConfigurationHelper implements ContainerInjectionInterface {
       $this->indexAddFacetField($index);
       $index->save();
     }
-    $this->createFacet();
+
+    if ($index && $index->status()) {
+      $this->createFacet(Constants::FACET_CONFIG_ENTITY_ID, Constants::FACET_CONFIG_FILE);
+    }
   }
 
   /**
@@ -314,13 +317,13 @@ class ConfigurationHelper implements ContainerInjectionInterface {
   /**
    * Import config entity for the directory Facet.
    */
-  public function createFacet(): void {
-    if ($this->entityTypeManager->getStorage('facets_facet')->load(Constants::FACET_CONFIG_ENTITY_ID)) {
+  public function createFacet(string $facet_id, string $facet_cfg_file): void {
+    if ($this->entityTypeManager->getStorage('facets_facet')->load($facet_id)) {
       return;
     }
 
     $conditional_config_path = $this->moduleExtensionList->getPath('localgov_directories') . '/config/conditional';
-    if ($this->importConfigEntity('facets_facet', $conditional_config_path, Constants::FACET_CONFIG_FILE)) {
+    if ($this->importConfigEntity('facets_facet', $conditional_config_path, $facet_cfg_file)) {
       $this->configInstaller->installOptionalConfig();
     }
   }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -11,18 +11,42 @@ class Constants {
 
   const DEFAULT_INDEX = 'localgov_directories_index_default';
 
+  const LOCATION_FIELD = 'localgov_location';
+
+  const LOCATION_MODULE = 'localgov_directories_location';
+
+  const PROXIMITY_SEARCH_CFG_FIELD = 'localgov_proximity_search_cfg';
+
   const CHANNEL_SEARCH_BLOCK = 'localgov_directories_channel_search_block';
 
   const CHANNEL_SELECTION_FIELD = 'localgov_directory_channels';
 
   const TITLE_SORT_FIELD = 'localgov_directory_title_sort';
 
+  const SEARCH_API_LOCATION_DATATYPE = 'location';
+
   const FACET_INDEXING_FIELD = 'localgov_directory_facets_filter';
 
   const FACET_SELECTION_FIELD = 'localgov_directory_facets_select';
 
+  const FACET_TYPE_CONFIG_ENTITY_ID = 'localgov_directories_facets_type';
+
   const FACET_CONFIG_ENTITY_ID = 'localgov_directories_facets';
 
   const FACET_CONFIG_FILE = 'facets.facet.localgov_directories_facets';
+
+  const FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH = 'localgov_directories_facets_proximity_search';
+
+  const FACET_CONFIG_FILE_FOR_PROXIMITY_SEARCH = 'facets.facet.localgov_directories_facets_proximity_search';
+
+  const CHANNEL_VIEW = 'localgov_directory_channel';
+
+  const CHANNEL_VIEW_DISPLAY = 'node_embed';
+
+  const CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY = 'node_embed_for_proximity_search';
+
+  const CHANNEL_VIEW_MAP_DISPLAY = 'embed_map';
+
+  const CHANNEL_NODE_BUNDLE = 'localgov_directory';
 
 }

--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -15,6 +15,7 @@ use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Security\TrustedCallbackInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\localgov_directories\Constants as Directory;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
 use Drupal\node\NodeInterface;
@@ -157,7 +158,7 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
     $node_types = $this->entityTypeManager->getStorage('node_type')->loadMultiple();
     foreach ($node_types as $type_id => $type) {
       $fields = $this->entityFieldManager->getFieldDefinitions('node', $type_id);
-      if (isset($fields['localgov_directory_channels'])) {
+      if (isset($fields[Directory::CHANNEL_SELECTION_FIELD])) {
         $entry_types[$type_id] = $type_id;
       }
     }
@@ -189,14 +190,15 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
    * Retrieves view, and sets render array.
    */
   protected function getViewEmbed(NodeInterface $node, $search_filter = FALSE) {
-    $view = Views::getView('localgov_directory_channel');
-    if (!$view || !$view->access('node_embed')) {
+    $view = Views::getView(Directory::CHANNEL_VIEW);
+    $views_display = self::determineChannelViewDisplay($node);
+    if (!$view || !$view->access($views_display)) {
       return;
     }
     $render = [
       '#type' => 'view',
-      '#name' => 'localgov_directory_channel',
-      '#display_id' => 'node_embed',
+      '#name' => Directory::CHANNEL_VIEW,
+      '#display_id' => $views_display,
       '#arguments' => [$node->id()],
     ];
     if (!$search_filter) {
@@ -213,12 +215,14 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
   protected function getFacetsBlock(NodeInterface $node) {
     // The facet manager build needs the results of the query. Which might not
     // have been run by our nicely lazy loaded views render array.
-    $view = Views::getView('localgov_directory_channel');
+    $view = Views::getView(Directory::CHANNEL_VIEW);
     $view->setArguments([$node->id()]);
-    $view->execute('node_embed');
+    $views_display = self::determineChannelViewDisplay($node);
+    $view->execute($views_display);
 
     if (!empty($view->result)) {
-      $block = $this->pluginBlockManager->createInstance('facet_block' . PluginBase::DERIVATIVE_SEPARATOR . 'localgov_directories_facets');
+      $facet_id = self::determineFacetForChannel($node);
+      $block = $this->pluginBlockManager->createInstance('facet_block' . PluginBase::DERIVATIVE_SEPARATOR . $facet_id);
       return $block->build();
     }
     else {
@@ -232,10 +236,11 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
   protected function getSearchBlock(NodeInterface $node) {
     $forms = $form_list = [];
     foreach ($node->localgov_directory_channels as $delta => $channel) {
-      $view = Views::getView('localgov_directory_channel');
-      if ($view && ($node = $channel->entity)) {
-        $view->setDisplay('node_embed');
-        $view->setArguments([$node->id()]);
+      $view = Views::getView(Directory::CHANNEL_VIEW);
+      if ($view && ($channel_node = $channel->entity)) {
+        $views_display = self::determineChannelViewDisplay($channel_node);
+        $view->setDisplay($views_display);
+        $view->setArguments([$channel_node->id()]);
         $view->initHandlers();
         $form_state = (new FormState())
           ->setStorage([
@@ -247,10 +252,10 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
           ->setAlwaysProcess()
           ->disableRedirect();
         $form = $this->formBuilder->buildForm('\Drupal\views\Form\ViewsExposedForm', $form_state);
-        $form['#action'] = $node->toUrl()->toString();
+        $form['#action'] = $channel_node->toUrl()->toString();
         $form['#attributes']['class'][] = $delta ? 'localgov-search-channel-secondary' : 'localgov-search-channel-primary';
-        $channel_label = $this->entityRepository->getTranslationFromContext($node)->label();
-        $form['#id'] .= '--' . $node->id();
+        $channel_label = $this->entityRepository->getTranslationFromContext($channel_node)->label();
+        $form['#id'] .= '--' . $channel_node->id();
         $form["#info"]["filter-search_api_fulltext"]["label"] = $this->t('Search <span class="localgov-search-channel" id="@id--channel">@channel</span>', [
           '@id' => $form['#id'],
           '@channel' => $channel_label,
@@ -278,7 +283,7 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
    */
   public function preprocessFacetList(array &$variables) {
     $facet_storage = $this->entityTypeManager
-      ->getStorage('localgov_directories_facets');
+      ->getStorage(Directory::FACET_CONFIG_ENTITY_ID);
     $group_items = [];
     foreach ($variables['items'] as $key => $item) {
       if ($entity = $facet_storage->load($item['value']['#attributes']['data-drupal-facet-item-value'])) {
@@ -287,7 +292,7 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
       }
     }
     $type_storage = $this->entityTypeManager
-      ->getStorage('localgov_directories_facets_type');
+      ->getStorage(Directory::FACET_TYPE_CONFIG_ENTITY_ID);
     foreach ($group_items as $bundle => $items) {
       $entity = $type_storage->load($bundle);
       assert($entity instanceof LocalgovDirectoriesFacetsType);
@@ -316,6 +321,34 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
     }
 
     return $bundle1['weight'] < $bundle2['weight'] ? -1 : 1;
+  }
+
+  /**
+   * Finds the relevant Views display.
+   *
+   * Determines if the given directory channel needs the usual Views display or
+   * a proximity search display.
+   */
+  public static function determineChannelViewDisplay(NodeInterface $channel_node): string {
+
+    $has_proximity_search = $channel_node->hasField(Directory::PROXIMITY_SEARCH_CFG_FIELD) && !empty($channel_node->{Directory::PROXIMITY_SEARCH_CFG_FIELD}->value);
+    $views_display = $has_proximity_search ? Directory::CHANNEL_VIEW_PROXIMITY_SEARCH_DISPLAY : Directory::CHANNEL_VIEW_DISPLAY;
+    return $views_display;
+  }
+
+  /**
+   * Finds the relevant Facet for a directory channel.
+   *
+   * Channels use different Views displays depending on whether proximity search
+   * is in use or not.  The directory related Facets are attached to these Views
+   * displays.  This means the choice of Facet differs depending on the use of
+   * proximity search.
+   */
+  public static function determineFacetForChannel(NodeInterface $channel_node): string {
+
+    $has_proximity_search = $channel_node->hasField(Directory::PROXIMITY_SEARCH_CFG_FIELD) && !empty($channel_node->{Directory::PROXIMITY_SEARCH_CFG_FIELD}->value);
+    $facet_id = $has_proximity_search ? Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH : Directory::FACET_CONFIG_ENTITY_ID;
+    return $facet_id;
   }
 
   /**


### PR DESCRIPTION
Squashed commit of the following:

commit ca0c85b2c1c81280ca34643f5ea31fa79dfc7f2c
Author: ekes <ekes@iskra.net>
Date:   Mon Mar 27 12:19:24 2023 +0200

    Update to Searh API with location support.

commit cc38125656c07fae27eea180996879de3c8bc89c
Author: Adnan <50206849+Adnan-cds@users.noreply.github.com>
Date:   Tue Mar 7 10:42:23 2023 +0000

    Doc: Supported database backends

    Adding minimum supported database versions for location-based search.

commit 51fc73d887620cacc1a3d86031379dfdc28d1ef0
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Tue Feb 21 16:30:46 2023 +0000

    Fix(Proximity search): Merge error.

commit 3f44a4948450d8ca81c3ff3c1c26b7d991ee172f
Merge: 4c3bc6d 5d064f3
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Tue Feb 21 16:28:58 2023 +0000

    Merge remote-tracking branch 'origin/2.x' into feature/2.x/189-proximity-search

commit 4c3bc6d10fce682c6f4ffdf8f1459d0091a092f2
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Mon Dec 12 12:09:24 2022 +0000

    Patch: Dropped redundant patches.

commit aa033be91f3c01456ac1d8f82233770434f937a7
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 16 22:28:47 2022 +0000

    Fix(Distance): Round figures for distance options.

    Solr ignores fraction values in location queries.  So 0.5km is treated as 0km
    and 1.5km is treated as 1km.  To avoid confusion, our Location View's filter
    now uses round values for distance in Kilometer.  This means the given values
    are not fully equivalent to their distance in miles.  For example, we are now
    using 3km for 2miles even though the exact value is 3.2km.

    It should be noted that Solr's default distance unit is Kilometer whereas
    MySQL's is meter.

commit beaeb1047078facf31805db64875c9d3bafc2d21
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 16 20:51:29 2022 +0000

    Test: Marking the relevant test as skipped.

    The removal of the search_api patch for location search in MySQL means the
    localgov_directories_db module is now unable to support Proximity search.
    Marking the related Kernel test as skipped.

commit 22fd158847de9ff7454fcd5c269afda9d73293c2
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 16 20:19:16 2022 +0000

    Refactor(Setup): Readability.

    Concentrated the Proximity search setup code into a single PHP class.

commit 58609990c20ea66b47529947d880c4a364c8856e
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 16 00:17:23 2022 +0000

    Feat(Proximity search): Dropping database search patch.

    Dropping the work-in-progress MySQL spatial search patch.

commit 8d88c8f810887904931ed368944bc01ddc3925c4
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Tue Nov 15 19:59:55 2022 +0000

    Fix(Proximity search): Activation.

    Do not enable Proximity search when the Directory search index is disabled.

commit dda5d82842ffc0bdafcc9b955a2d0188c418dca1
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Mon Nov 14 16:58:34 2022 +0000

    Doc(Proximity search): Explained the Prerequisites.

commit e5696b46cceaac7431c71cb46e9da643e6aba089
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Fri Nov 11 20:54:07 2022 +0000

    Feat(Proximity search): Check search backend capability.

    Do not add proximity search unless search backend supports location search.

commit 0c3bf4d301b21be5bf74fa1f81192e5c231cd9ce
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Fri Nov 11 11:21:59 2022 +0000

    Fix(test): Account for localgov_directories_db.

    Activates the localgov_directories_db submodule as part of the test.  We cannot
    have Directory search without this *new* submodule.

commit 999d691b7ad5ef9426dcad127da2dcc4fc444c02
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 9 17:33:08 2022 +0000

    Fix(Patch URL): Patch for search_api_location.

commit 1abc1860b970c05a86774bb8f513945d053d0aed
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Nov 9 17:23:54 2022 +0000

    Fix(Proximity search): Patch update for search_api_location.

commit 9a1738e8f116a06141f4006860cc8ad29f0abf17
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Fri Nov 4 20:59:39 2022 +0000

    Fix(Proximity search): Account for localgov_directories_db.

    When the localgov_directories_default_index search index is disabled, do not add
    any Directory facet.  This can happen when the localgov_directories_venue module
    is enabled before the new localgov_directories_db module.

commit bdbf672f37884c3c67a2bfd8e08e5169ed942d66
Merge: 31dab97 5a4c973
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Fri Nov 4 11:44:42 2022 +0000

    Merge remote-tracking branch 'origin/2.x' into feature/2.x/189-proximity-search

commit 31dab979ea94d2839eb0297218625bdcf9f1c4c5
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Sun Jul 17 13:23:58 2022 +0100

    Fix(Proximity search): Test failure.

    Github test runner test failure caused by lack of search_api config settings.

commit 4b7e085fea139b745e9ba064f2dc2ff75f9ef2ad
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Sun Jul 17 10:50:56 2022 +0100

    Feat(Proximity search): Kernel test.

    Test to verify programmatic addition of new view display for proximity search
    to the channel view.

commit e99649f346bf9f35ce570ef846db07980e6e27a3
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Fri Jul 15 15:56:23 2022 +0100

    Feat(Proximity search): Facets.

    Facets are now available for proximity search.

commit 25b98d27a36d9f8a4fa627d53612a52d69e149ce
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Thu Jul 14 22:30:44 2022 +0100

    Fix(Proximity search): Programmatic updates.

    - Added missing dependency classes in install file.
    - The embedded map display of the directory channel view is also overridden for
      location-based search.

commit ae8719df8034e9c25920b4500c40cb6407696dba
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Thu Jul 14 17:51:29 2022 +0100

    Feat(Proximity search): Search option.

    Directory channels can now use proximity search if the corresponding setting is
    activated in the channel edit form.  To achieve this, channels will either use
    the node_embed or the node_embed_with_proximity_search displays of the
    localgov_directory_channel View.

commit cc3947381c92e9316fbbb8a4fbd42c0a6c91b96b
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Wed Jul 13 17:58:23 2022 +0100

    Feat(Proximity search): Configuration.

    - Moved Proximity search config field definition into the
      localgov_directories_location submodule.
    - Moved the programmatic updates for the Proximity search config field into the
      localgov_directories_location submodule.
    - Views display for proximity search.

commit f45b51357507e81a14579e287c2866fd01883e51
Author: Adnan <adnan.muhammad@croydon.gov.uk>
Date:   Mon Jul 11 20:04:49 2022 +0100

    Feat(Proximity search): Config field.

    Adding the localgov_proximity_search_cfg field to the localgov_directory content
    type.  The value of this field indicates if a Directory channel should offer
    proximity search or not.