### PR TITLE
Fix(Proximity search): Facet display

### DIFF
--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -29,13 +29,26 @@ function localgov_directories_theme() {
     'facets_item_list__links__localgov_directories_facets' => [
       'base hook' => 'facets_item_list',
     ],
+    // Facets for proximity search look no different.
+    'facets_item_list__links__localgov_directories_facets_proximity_search' => [
+      'base hook' => 'facets_item_list',
+      'template'  => 'facets-item-list--links--localgov-directories-facets',
+    ],
     // Facet Checkboxes are rendered through Javascript.  So the same markup as
     // "link" Facets suffices.
     'facets_item_list__checkbox__localgov_directories_facets' => [
       'base hook' => 'facets_item_list',
       'template'  => 'facets-item-list--links--localgov-directories-facets',
     ],
+    'facets_item_list__checkbox__localgov_directories_facets_proximity_search' => [
+      'base hook' => 'facets_item_list',
+      'template'  => 'facets-item-list--links--localgov-directories-facets',
+    ],
     'facets_item_list__dropdown__localgov_directories_facets' => [
+      'base hook' => 'facets_item_list',
+      'template'  => 'facets-item-list--dropdown--localgov-directories-facets',
+    ],
+    'facets_item_list__dropdown__localgov_directories_facets_proximity_search' => [
       'base hook' => 'facets_item_list',
       'template'  => 'facets-item-list--dropdown--localgov-directories-facets',
     ],
@@ -171,12 +184,11 @@ function localgov_directories_field_config_delete(FieldConfigInterface $field) {
  * @see facets_preprocess_facets_item_list()
  */
 function localgov_directories_preprocess_facets_item_list(array &$variables) {
-  if (!empty($variables['facet']) && ($variables['facet']->id() == 'localgov_directories_facets')) {
+  if (!empty($variables['facet']) && ($variables['facet']->id() === Directory::FACET_CONFIG_ENTITY_ID || $variables['facet']->id() === Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH)) {
     \Drupal::service('class_resolver')
       ->getInstanceFromDefinition(DirectoryExtraFieldDisplay::class)
       ->preprocessFacetList($variables);
   }
-
 }
 
 /**


### PR DESCRIPTION
Facet preprocessing and template selection is broken in the proximity search views display of the Directory channel view.  Fixed now.

## How to reproduce
0. Add one or more Facet types (e.g. "Location") to a Directory channel.
1. Enable proximity search for that Directory channel.
2. Add a few Directory venues to the above channel.
3. Ensure these Directory venues are using the facet values from step 0.
4. Open the Directory channel page and look at the facet block on the sidebar.
5. While the facet values are present as a **flat list**, the facet type labels (e.g. "Location") are absent.  This is because the [facet preprocessor]( [https://github.com/localgovdrupal/localgov_directories/blob/0325940bfcfb7d7bca4b71709c4efb3b93f2c5bd/localgov_directories.module#L174]) has no knowledge of the [facet used in proximity search](https://github.com/localgovdrupal/localgov_directories/blob/2.x/config/conditional/facets.facet.localgov_directories_facets_proximity_search.yml).

## Screenshots
- [Current](https://user-images.githubusercontent.com/50206849/229347356-39173fea-bd1b-4867-9f81-c39cc4a119db.png)
- [Expected](https://user-images.githubusercontent.com/50206849/229347369-efd262f1-681a-4f72-a909-1678afd4ca3d.png)
