### PR TITLE
Fix #275: Only import services navigation field optional configuration.

### DIFF
--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -83,7 +83,9 @@ function localgov_directories_localgov_roles_default() {
 function localgov_directories_modules_installed($modules) {
   $services = in_array('localgov_services_navigation', $modules);
   if ($services) {
-    \Drupal::service('config.installer')->installOptionalConfig();
+    \Drupal::service('config.installer')->installOptionalConfig(NULL, [
+      'config' => 'field.storage.node.localgov_services_parent',
+    ]);
     localgov_directories_optional_fields_settings($services);
   }
 }

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -324,7 +324,9 @@ class ConfigurationHelper implements ContainerInjectionInterface {
 
     $conditional_config_path = $this->moduleExtensionList->getPath('localgov_directories') . '/config/conditional';
     if ($this->importConfigEntity('facets_facet', $conditional_config_path, $facet_cfg_file)) {
-      $this->configInstaller->installOptionalConfig();
+      $this->configInstaller->installOptionalConfig(NULL, [
+        'config' => 'facets.facet.localgov_directories_facets',
+      ]);
     }
   }
 


### PR DESCRIPTION
@andybroomfield You want to review this?
@stephen-cox As it's only mentioning navigation here I'm assuming there's no other optional field we're accidentally relying on getting imported? I've looked through the submodules optional and can't see anything.