### PR TITLE
Make facets on a channel optional, as is documented from #281.

### DIFF
--- a/config/install/field.field.node.localgov_directory.localgov_directory_facets_enable.yml
+++ b/config/install/field.field.node.localgov_directory.localgov_directory_facets_enable.yml
@@ -10,7 +10,7 @@ entity_type: node
 bundle: localgov_directory
 label: 'Enabled Facets'
 description: 'Which facets are enabled to be shown on this directory channel, and will be added when editing content to be added to this directory.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Doing dev on a channel that doesn't use content facet, but taxonomy facets instead, and keep getting reminded this field isn't actually compulsory. So figured rather than unticking it every time I reinstall I should make a PR :)