### PR TITLE
Re-run core update for our blocks added after the fact.

### DIFF
--- a/localgov_directories.post_update.php
+++ b/localgov_directories.post_update.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for LocalGov Directories.
+ */
+
+/**
+ * Updates the node type visibility condition.
+ *
+ * This was inluded in core D9 as block_post_update_replace_node_type_condition
+ * but we had installed condition plugins with this after it might have run.
+ * No harm in running this multiple times.
+ */
+function localgov_directories_post_update_replace_node_type_condition() {
+  $config_factory = \Drupal::configFactory();
+  foreach ($config_factory->listAll('block.block.') as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}


### PR DESCRIPTION
As per comment in the code. We've added config with deprecated plugin after the core update. So this just runs it again. Doing so in all the modules we added this config would make sense.

This does to existing sites what https://github.com/localgovdrupal/localgov_directories/commit/8d9c8919d8ec4994077475286a9da8068df3f354 did for new installs.