### PR TITLE
[3.x] Fixes the missing show reset link 

### DIFF
--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -294,6 +294,17 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
    * @see localgov_directories_preprocess_facets_item_list()
    */
   public function preprocessFacetList(array &$variables) {
+    $reset_all = NULL;
+    $show_reset_link = [];
+
+    // Check if the show reset link has been enabled.
+    foreach ($variables['items'] as $key => $item) {
+      if ($variables["items"][$key]["value"]["#attributes"]["data-drupal-facet-item-value"] == 'reset_all') {
+        $variables["attributes"]["class"][] = "facet-show-reset";
+        $show_reset_link = current($variables["items"]);
+      }
+    }
+
     $facet_storage = $this->entityTypeManager
       ->getStorage(Directory::FACET_CONFIG_ENTITY_ID);
     $group_items = [];
@@ -327,6 +338,17 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
     }
     uasort($group_items, 'static::compareFacetBundlesByWeight');
     $variables['items'] = $group_items;
+
+    if (!empty($show_reset_link)) {
+      // Add the reset link.
+      $variables['items']['show_reset_all']['items'][] = $show_reset_link;
+      $reset_all = $variables['items']['show_reset_all'];
+      // Place the reset link at the top of the facet filters.
+      array_unshift($variables['items'], $reset_all);
+      array_pop($variables['items']);
+
+    }
+
   }
 
   /**

--- a/tests/src/Functional/ResetFacetFilterTest.php
+++ b/tests/src/Functional/ResetFacetFilterTest.php
@@ -99,6 +99,10 @@ class ResetFacetFilterTest extends BrowserTestBase {
     $id = 'localgov_directories_facets';
     $this->drupalLogin($this->adminUser);
 
+    // Not displaying the reset link..
+    $this->drupalGet('node/' . $this->directory_channel_node_id);
+    $this->assertSession()->ElementNotExists('css', '.facets-reset');
+
     $this->drupalGet('admin/config/search/facets/' . $id . '/edit');
     $this->assertSession()->pageTextContains('Edit Facets facet');
 
@@ -124,9 +128,9 @@ class ResetFacetFilterTest extends BrowserTestBase {
     $this->assertSession()->checkboxChecked('widget_config[show_numbers]');
     $this->assertSession()->checkboxChecked('widget_config[show_reset_link]');
 
-    // Display the Directory Channel page.
+    // Now displaying the reset link.
     $this->drupalGet('node/' . $this->directory_channel_node_id);
-    $this->assertSession()->responseContains('facet-item__count');
+    $this->assertSession()->ElementExists('css', '.facets-reset');
   }
 
 }

--- a/tests/src/Functional/ResetFacetFilterTest.php
+++ b/tests/src/Functional/ResetFacetFilterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories\Functional;
+
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
+use Drupal\node\NodeInterface;
+use Drupal\search_api\Entity\Index as SearchIndex;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the existence of the localgov_directories_facets facet edit page.
+ *
+ * @group localgov_directories
+ */
+class ResetFacetFilterTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'claro';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_directories',
+    'localgov_directories_db',
+    'localgov_directories_page',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->adminUser = $this->drupalCreateUser([
+      'administer facets',
+    ]);
+
+    // To submit a directory we need a facet.
+    $facet_type_id = $this->randomMachineName();
+    $facet_type = LocalgovDirectoriesFacetsType::create([
+      'id' => $facet_type_id,
+      'label' => $facet_type_id,
+    ]);
+    $facet_type->save();
+
+    $facet = LocalgovDirectoriesFacets::create([
+      'bundle' => $facet_type_id,
+      'title' => $this->randomMachineName(),
+    ]);
+    $facet->save();
+
+    // Directory Channel.
+    $directory = $this->createNode([
+      'title' => 'Test Channel',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_directory_facets_enable' => [$facet_type_id],
+    ]);
+
+    $directory->save();
+
+    $this->directory_channel_node_id = $directory->id();
+
+    // Directory pages.
+    for ($j = 1; $j < 3; $j++) {
+      $directory_page = $this->createNode([
+        'title' => 'Page ' . $j,
+        'type' => 'localgov_directories_page',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_channels' => [$directory->id()],
+        'localgov_directory_facets_select' => [$facet->id()],
+      ]);
+      $directory_page->save();
+    }
+
+    // Directory listings are sourced from a search index.
+    SearchIndex::load('localgov_directories_index_default')->indexItems();
+
+    $this->drupalPlaceBlock('facet_block:localgov_directories_facets');
+  }
+
+  /**
+   * Grab the localgov_directories_facets facet edit page.
+   */
+  public function testShowResetFilterLink() {
+
+    $id = 'localgov_directories_facets';
+    $this->drupalLogin($this->adminUser);
+
+    $this->drupalGet('admin/config/search/facets/' . $id . '/edit');
+    $this->assertSession()->pageTextContains('Edit Facets facet');
+
+    $this->assertSession()->fieldExists('widget_config[show_numbers]');
+    $this->assertSession()->checkboxNotChecked('widget_config[show_numbers]');
+
+    $this->assertSession()->fieldExists('widget_config[show_reset_link]');
+    $this->assertSession()->checkboxNotChecked('widget_config[show_reset_link]');
+
+    $this->assertSession()->fieldExists('widget_config[hide_reset_when_no_selection]');
+    $this->assertSession()->checkboxNotChecked('widget_config[hide_reset_when_no_selection]');
+
+    // Change the facet settings.
+    $edit = [
+      'widget_config[show_numbers]' => TRUE,
+      'widget_config[show_reset_link]' => TRUE,
+      'widget_config[hide_reset_when_no_selection]' => FALSE,
+    ];
+
+    $this->submitForm($edit, 'Save');
+    $this->drupalGet('admin/config/search/facets/localgov_directories_facets/edit');
+
+    $this->assertSession()->checkboxChecked('widget_config[show_numbers]');
+    $this->assertSession()->checkboxChecked('widget_config[show_reset_link]');
+
+    // Display the Directory Channel page.
+    $this->drupalGet('node/' . $this->directory_channel_node_id);
+    $this->assertSession()->responseContains('facet-item__count');
+  }
+
+}


### PR DESCRIPTION
D10 fix for showing the 'reset all' facet option. D9 version #305 