### PR TITLE
[3.x] Facet group OR within AND accross groups

### DIFF
--- a/config/conditional/facets.facet.localgov_directories_facets.yml
+++ b/config/conditional/facets.facet.localgov_directories_facets.yml
@@ -54,6 +54,11 @@ processor_configs:
     processor_id: weight_property_order
     weights:
       build: -5
+  localgov_directories_processor:
+    processor_id: localgov_directories_processor
+    weights:
+      pre_query: 35
+    settings: {  }
 empty_behavior:
   behavior: none
 show_title: false

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -237,3 +237,10 @@ function localgov_directories_leaflet_map_view_style_alter(&$js_settings, $leafl
   // This can be used in template if needed.
   $js_settings['map']['is_empty'] = empty($js_settings['features']);
 }
+
+/**
+ * Implements hook_facets_search_api_query_type_mapping_alter().
+ */
+function localgov_directories_facets_search_api_query_type_mapping_alter($backend_plugin_id, array &$query_types) {
+  $query_types['localgov_directories'] = 'localgov_directories_query_type';
+}

--- a/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
+++ b/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\localgov_directories\Plugin\facets\processor;
+
+use Drupal\facets\FacetInterface;
+//use Drupal\facets\Processor\BuildProcessorInterface;
+use Drupal\facets\Processor\PreQueryProcessorInterface;
+use Drupal\facets\Processor\ProcessorPluginBase;
+
+/**
+ * ANDs LocalGov Directories Facet Groups while keeping OR within each group.
+ *
+ * @FacetsProcessor(
+ *   id = "localgov_directories_processor",
+ *   label = @Translation("LocalGov Directories - AND Facet Groups"),
+ *   description = @Translation("ANDs LocalGov Directories Facet Groups while keeping OR within each group."),
+ *   stages = {
+ *     "pre_query" = 35
+ *   }
+ * )
+ */
+//class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements BuildProcessorInterface {
+class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements PreQueryProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  //public function build(FacetInterface $facet, array $results) {
+   // return $results;
+  //}
+  public function preQuery(FacetInterface $facet) {
+    $active_items = $facet->getActiveItems();
+    $facet->setActiveItems($active_items);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * String corresponds to a key on the $query_types array as defined
+   * within hook_facets_search_api_query_type_mapping_alter().
+   *
+   * @see hook_facets_search_api_query_type_mapping_alter()
+   */
+  public function getQueryType() {
+    return 'localgov_directories';
+  }
+
+}

--- a/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
+++ b/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
@@ -39,4 +39,5 @@ class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements PreQue
   public function getQueryType() {
     return 'localgov_directories';
   }
+
 }

--- a/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
+++ b/src/Plugin/facets/processor/LocalGovDirectoriesProcessor.php
@@ -3,7 +3,6 @@
 namespace Drupal\localgov_directories\Plugin\facets\processor;
 
 use Drupal\facets\FacetInterface;
-//use Drupal\facets\Processor\BuildProcessorInterface;
 use Drupal\facets\Processor\PreQueryProcessorInterface;
 use Drupal\facets\Processor\ProcessorPluginBase;
 
@@ -19,15 +18,11 @@ use Drupal\facets\Processor\ProcessorPluginBase;
  *   }
  * )
  */
-//class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements BuildProcessorInterface {
 class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements PreQueryProcessorInterface {
 
   /**
    * {@inheritdoc}
    */
-  //public function build(FacetInterface $facet, array $results) {
-   // return $results;
-  //}
   public function preQuery(FacetInterface $facet) {
     $active_items = $facet->getActiveItems();
     $facet->setActiveItems($active_items);
@@ -44,5 +39,4 @@ class LocalGovDirectoriesProcessor extends ProcessorPluginBase implements PreQue
   public function getQueryType() {
     return 'localgov_directories';
   }
-
 }

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -71,7 +71,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     // Get passed in facets.
     $temp_query = $this->query->getOriginalQuery();
     $temp_query->preExecute();
-    $conditions = &$temp_query->getConditionGroup()->getConditions();
+    $conditions = $temp_query->getConditionGroup()->getConditions();
 
     // Find all the facet condition groups.
     $facet_conditions = [];
@@ -147,7 +147,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     $filter_query->preExecute();
 
     // Find conditions.
-    $conditions = &$filter_query->getConditionGroup()->getConditions();
+    $conditions = $filter_query->getConditionGroup()->getConditions();
 
     // Store removed conditions so we can reset them.
     $removed_conditions = [];
@@ -172,10 +172,8 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     $facets = $filter_query->getResults()->getExtraData('search_api_facets');
     $filter_query->postExecute();
 
-    // Beacuse for reasons unknown, removing the conditions removes it from all
-    // the following queries, even though we are fetching the original query.
-    // We can get around that by readding the conditions back in now that we
-    // have the facets we want.
+    // Without deep cloning we've affected the conditions, reset these for the
+    // query.
     $conditions = array_merge($conditions, $removed_conditions);
 
     // Since we will get every facet from the passed in facet group,

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -66,32 +66,43 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
   public function build() {
     $results = $this->results;
     $query_operator = $this->facet->getQueryOperator();
+    $field_identifier = $this->facet->getFieldIdentifier();
+
+    // Get passed in facets.
     $temp_query = $this->query->getOriginalQuery();
     $temp_query->preExecute();
     $conditions = &$temp_query->getConditionGroup()->getConditions();
+
+    // Find all the facet condition groups.
+    $facet_conditions = [];
     foreach ($conditions as $key => $condition) {
-      if ($condition instanceof \Drupal\search_api\Query\ConditionGroupInterface) {
+      if ($condition instanceof ConditionGroupInterface) {
         $tags = $condition->getTags();
         foreach($tags as $tag) {
-          if (strpos($tag, 'facet:localgov_directory_facets_filter.') === 0) {
-            // unset($conditions[$key]);
-            $results = array_merge($results, $this->getGroupFacets($tag));
+          if (strpos($tag, 'facet:' . $field_identifier . '.') === 0) {
+            $facet_conditions[$key] = $tag;
           }
         }
       }
     }
-    $filtered_results[] = reset($results);
-    foreach ($results as $result) {
-      $current_results = array_column($filtered_results, 'filter');
-      if (!in_array($result['filter'], $current_results)) {
-        $filtered_results[] = $result;
-      }
-    }
-    $results = $filtered_results;
-    // $temp_query->execute();
-    // $avalible_facets = $temp_query->getResults()->getExtraData('search_api_facets');
-    // $results = $avalible_facets['localgov_directory_facets_filter'] ?? $this->results;
 
+    // Run query elimnating each facet group and return the resulting facets.
+    $results = $this->results;
+    foreach($facet_conditions as $key => $filter_tag) {
+      $group_facets = $this->getResultingFacetsFromFacetGroupExceptOwn($filter_tag);
+      
+      // Remove any duplicate facets, or they show up multiple times.
+      $group_facets_filtered = array_filter($group_facets, function($item) use ($results) {
+        $facet_ids = array_column($results, 'filter');
+        if (in_array($item['filter'], $facet_ids)) {
+          return FALSE;
+        }
+        return TRUE;
+      });
+      $results = array_merge($results, $group_facets_filtered);
+    }
+
+    // Build facets.
     if (!empty($results)) {
       $facet_results = [];
       foreach ($results as $result) {
@@ -114,18 +125,78 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     return $this->facet;
   }
 
-  protected function getGroupFacets($filter_tag) {
-    $filter_query = $this->query->getOriginalQuery();
+  /**
+   * Get facets from a facet group except it's own with a corresponding tag
+   * 
+   * Re-run the search api query, this time removing all the other facet groups
+   * except the one specified by the filter tag. The purpose of this is to get
+   * the other facets that would be limited by setting of the passed in groups
+   * facets. It allows us to see the other possible facets that could be 
+   * selected as part of an 'OR' group 'AND' the facets selected in the passed
+   * in group.
+   *
+   * @param String $filter_tag
+   *   The search api tag of the facet group.
+   * @return Array
+   *   Search api query facet results.
+   */
+  protected function getResultingFacetsFromFacetGroupExceptOwn(String $filter_tag):Array {
+
+    // Set up a special filter query which needs to clone the original.
+    $filter_query = clone $this->query->getOriginalQuery();
     $filter_query->preExecute();
+
+    // Find conditions
     $conditions = &$filter_query->getConditionGroup()->getConditions();
+
+    // Store removed conditions so we can reset them.
+    $removed_conditions = [];
+
+    // Loop through each conditions, removing ones that are not this filter tag.
     foreach ($conditions as $tag => $condition) {
-      if ($condition instanceof ConditionGroupInterface && $condition->hasTag($filter_tag)) {
-        unset($conditions[$tag]);
+      if ($condition instanceof ConditionGroupInterface) {
+        $tags = $condition->getTags();
+
+        // @todo Check that we are only removing facet conditions.
+        if (!in_array($filter_tag, $tags)) {
+
+          // Store the removed conditions and remove it.
+          $removed_conditions[$tag] = $conditions[$tag];
+          unset($conditions[$tag]);
+        }
       }
     }
+
+    // Execute the filter query and get the facets returned.
     $filter_query->execute();
     $facets = $filter_query->getResults()->getExtraData('search_api_facets');
-    return $facets['localgov_directory_facets_filter'] ?? [];
+    $filter_query->postExecute();
+
+    // Beacuse for reasons unknown, removing the conditions removes it from all
+    // the following queries, even though we are fetching the original query.
+    // We can get around that by readding the conditions back in now that we 
+    // have the facets we want.
+    $conditions = array_merge($conditions, $removed_conditions);
+
+    // Since we will get every facet from the passed in facet group,
+    // we need to filter those out so checks with other facet groups will
+    // show us only the ones that are reachable from this facet group.
+    $facet_type_id = substr($filter_tag, 39);
+    $group_facet_ids = \Drupal::entityTypeManager()
+      ->getStorage('localgov_directories_facets')
+      ->getQuery()
+      ->condition('bundle', $facet_type_id)
+      ->execute();
+    $found_facets = $facets['localgov_directory_facets_filter'] ?? [];
+    $found_facets = array_filter($found_facets, function($item) use($group_facet_ids) {
+      if (!in_array(intval(trim($item['filter'], '"')), $group_facet_ids)) {
+        return TRUE;
+      }
+      return FALSE;
+    });
+
+    // Finally return the found facets.
+    return $found_facets;
   }
 
 }

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -7,8 +7,7 @@ use Drupal\facets\Result\Result;
 use Drupal\search_api\Query\QueryInterface;
 
 /**
- * Provides support to "AND" facet groups while keeping the operator within a
- * facets as an "OR".
+ * "AND" facet groups while keeping the operator within a facets as an "OR".
  *
  * @FacetsQueryType(
  *   id = "localgov_directories_query_type",
@@ -47,6 +46,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
           $bundle[$directory_facet->bundle()][] = $directory_facet->id();
         }
 
+        $filter = NULL;
         foreach ($bundle as $bundle_name => $group_items) {
           unset($filter);
           $filter = $query->createConditionGroup($operator, ['facet:' . $field_identifier . '.' . $bundle_name]);

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\localgov_directories\Plugin\facets\query_type;
+
+use Drupal\facets\QueryType\QueryTypePluginBase;
+use Drupal\facets\Result\Result;
+use Drupal\search_api\Query\QueryInterface;
+
+/**
+ * Provides support to "AND" facet groups while keeping the operator within a
+ * facets as an "OR".
+ *
+ * @FacetsQueryType(
+ *   id = "localgov_directories_query_type",
+ *   label = @Translation("LocalGov Directories Facet Groups AND Query Type"),
+ * )
+ */
+class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $query = $this->query;
+
+    // Only alter the query when there's an actual query object to alter.
+    if (!empty($query)) {
+      $operator = $this->facet->getQueryOperator();
+      $field_identifier = $this->facet->getFieldIdentifier();
+      $exclude = $this->facet->getExclude();
+
+      if ($query->getProcessingLevel() === QueryInterface::PROCESSING_FULL) {
+        // Set the options for the actual query.
+        $options = &$query->getOptions();
+        $options['search_api_facets'][$field_identifier] = $this->getFacetOptions();
+      }
+
+      // Add the filter to the query if there are active values.
+      $active_items = $this->facet->getActiveItems();
+
+      if (count($active_items)) {
+
+        $type_storage = \Drupal::entityTypeManager()
+          ->getStorage('localgov_directories_facets');
+        $chosen_facets = $type_storage->loadMultiple($active_items);
+        foreach ($chosen_facets as $directory_facet) {
+          $bundle[$directory_facet->bundle()][] = $directory_facet->id();
+        }
+
+        foreach ($bundle as $bundle_name => $group_items) {
+          unset($filter);
+          $filter = $query->createConditionGroup($operator, ['facet:' . $field_identifier . '.' . $bundle_name]);
+          foreach ($group_items as $value) {
+            $filter->addCondition($this->facet->getFieldIdentifier(), $value, $exclude ? '<>' : '=');
+          }
+          $query->addConditionGroup($filter);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $query_operator = $this->facet->getQueryOperator();
+
+    if (!empty($this->results)) {
+      $facet_results = [];
+      foreach ($this->results as $result) {
+        if ($result['count'] || $query_operator === 'or') {
+          $result_filter = $result['filter'] ?? '';
+          if ($result_filter[0] === '"') {
+            $result_filter = substr($result_filter, 1);
+          }
+          if ($result_filter[strlen($result_filter) - 1] === '"') {
+            $result_filter = substr($result_filter, 0, -1);
+          }
+          $count = $result['count'];
+          $result = new Result($this->facet, $result_filter, $result_filter, $count);
+          $facet_results[] = $result;
+        }
+      }
+      $this->facet->setResults($facet_results);
+    }
+
+    return $this->facet;
+  }
+
+}

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -169,7 +169,6 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     // Execute the filter query and get the facets returned.
     $filter_query->execute();
     $facets = $filter_query->getResults()->getExtraData('search_api_facets');
-    // dpm($facets);
     $filter_query->postExecute();
 
     // Without deep cloning we've affected the conditions, reset these for the

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -78,7 +78,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     foreach ($conditions as $key => $condition) {
       if ($condition instanceof ConditionGroupInterface) {
         $tags = $condition->getTags();
-        foreach($tags as $tag) {
+        foreach ($tags as $tag) {
           if (strpos($tag, 'facet:' . $field_identifier . '.') === 0) {
             $facet_conditions[$key] = $tag;
           }
@@ -87,12 +87,11 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
     }
 
     // Run query elimnating each facet group and return the resulting facets.
-    $results = $this->results;
-    foreach($facet_conditions as $key => $filter_tag) {
+    foreach ($facet_conditions as $key => $filter_tag) {
       $group_facets = $this->getResultingFacetsFromFacetGroupExceptOwn($filter_tag);
-      
+
       // Remove any duplicate facets, or they show up multiple times.
-      $group_facets_filtered = array_filter($group_facets, function($item) use ($results) {
+      $group_facets_filtered = array_filter($group_facets, function ($item) use ($results) {
         $facet_ids = array_column($results, 'filter');
         if (in_array($item['filter'], $facet_ids)) {
           return FALSE;
@@ -126,27 +125,28 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
   }
 
   /**
-   * Get facets from a facet group except it's own with a corresponding tag
-   * 
+   * Get facets from a facet group except it's own with a corresponding tag.
+   *
    * Re-run the search api query, this time removing all the other facet groups
    * except the one specified by the filter tag. The purpose of this is to get
    * the other facets that would be limited by setting of the passed in groups
-   * facets. It allows us to see the other possible facets that could be 
+   * facets. It allows us to see the other possible facets that could be
    * selected as part of an 'OR' group 'AND' the facets selected in the passed
    * in group.
    *
-   * @param String $filter_tag
+   * @param string $filter_tag
    *   The search api tag of the facet group.
-   * @return Array
+   *
+   * @return array
    *   Search api query facet results.
    */
-  protected function getResultingFacetsFromFacetGroupExceptOwn(String $filter_tag):Array {
+  protected function getResultingFacetsFromFacetGroupExceptOwn(string $filter_tag): array {
 
     // Set up a special filter query which needs to clone the original.
     $filter_query = clone $this->query->getOriginalQuery();
     $filter_query->preExecute();
 
-    // Find conditions
+    // Find conditions.
     $conditions = &$filter_query->getConditionGroup()->getConditions();
 
     // Store removed conditions so we can reset them.
@@ -174,7 +174,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
 
     // Beacuse for reasons unknown, removing the conditions removes it from all
     // the following queries, even though we are fetching the original query.
-    // We can get around that by readding the conditions back in now that we 
+    // We can get around that by readding the conditions back in now that we
     // have the facets we want.
     $conditions = array_merge($conditions, $removed_conditions);
 
@@ -188,7 +188,7 @@ class LocalGovDirectoriesQueryType extends QueryTypePluginBase {
       ->condition('bundle', $facet_type_id)
       ->execute();
     $found_facets = $facets['localgov_directory_facets_filter'] ?? [];
-    $found_facets = array_filter($found_facets, function($item) use($group_facet_ids) {
+    $found_facets = array_filter($found_facets, function ($item) use ($group_facet_ids) {
       if (!in_array(intval(trim($item['filter'], '"')), $group_facet_ids)) {
         return TRUE;
       }

--- a/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+++ b/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
@@ -7,7 +7,7 @@ use Drupal\facets\Result\Result;
 use Drupal\search_api\Query\QueryInterface;
 
 /**
- * "AND" facet groups while keeping the operator within a facets as an "OR".
+ * AND facet groups while keeping the operator within a facets as an OR.
  *
  * @FacetsQueryType(
  *   id = "localgov_directories_query_type",

--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -215,7 +215,6 @@ class FacetsTest extends BrowserTestBase {
     // Check facets and check the right entries are shown.
     $directory_url = $channel_node->toUrl()->toString();
     $this->drupalGet($directory_url);
-    $this->assertSession()->statusCodeEquals(200);
 
     // Initially all four should be avalible.
     $this->assertSession()->pageTextContains($node_titles[0]);

--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -143,8 +143,11 @@ class FacetsTest extends BrowserTestBase {
 
   /**
    * Test facets filter with And groups.
+   *
+   * Verifies that the correct entries are visible using an OR filter within
+   * facet groups and a AND filter accross the groups.
    */
-  public function testFacetsFilters() {
+  public function testFacetsGroupFilters() {
 
     // Set up some directory entires.
     $directory_nodes = [
@@ -359,7 +362,7 @@ class FacetsTest extends BrowserTestBase {
         ],
       ],
       [
-        // Entry 3 has facet 2 only
+        // Entry 3 has facet 2 only.
         'title' => 'Entry 3 ' . $this->randomMachineName(8),
         'type' => 'localgov_directories_page',
         'body' => [
@@ -404,9 +407,6 @@ class FacetsTest extends BrowserTestBase {
     foreach ($directory_nodes as $node) {
       $this->createNode($node);
     }
-
-    // Get titles for comparison.
-    $node_titles = array_column($directory_nodes, 'title');
 
     // Run cron so the directory entires are indexed.
     $this->cronRun();

--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Drupal\Tests\localgov_directories\Functional;
+
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
+use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests facets on a directory channel as a filter.
+ *
+ * @group localgov_directories
+ */
+class FacetsTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use CronRunTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'block',
+    'localgov_search',
+    'localgov_search_db',
+    'facets',
+    'localgov_directories',
+    'localgov_directories_db',
+    'localgov_directories_page',
+  ];
+
+  /**
+   * Test facets filter with And groups.
+   */
+  public function testFacetsFilters() {
+
+    // Set up admin user.
+    $admin_user = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+      'administer blocks',
+    ]);
+
+    // Place the facet block.
+    $this->drupalLogin($admin_user);
+    $this->drupalPlaceBlock('facet_block:localgov_directories_facets', []);
+    $this->drupalLogout($admin_user);
+
+    // Set up facet types.
+    $facet_types = [
+      'Group 1 ' . $this->randomMachineName(8),
+      'Group 2 ' . $this->randomMachineName(8),
+    ];
+    foreach ($facet_types as $type_id) {
+      $type = LocalgovDirectoriesFacetsType::create([
+        'id' => $type_id,
+        'label' => $type_id,
+      ]);
+      $type->save();
+      $facet_type_entities[] = $type;
+    }
+
+    // Set up facets.
+    $facets = [
+      [
+        'bundle' => $facet_types[0],
+        'title' => 'Facet 1 ' . $this->randomMachineName(8),
+      ],
+      [
+        'bundle' => $facet_types[0],
+        'title' => 'Facet 2 ' . $this->randomMachineName(8),
+      ],
+      [
+        'bundle' => $facet_types[1],
+        'title' => 'Facet 3' . $this->randomMachineName(8),
+      ],
+      [
+        'bundle' => $facet_types[1],
+        'title' => 'Facet 4 ' . $this->randomMachineName(8),
+      ],
+    ];
+    foreach ($facets as $facet_item) {
+      $facet = LocalgovDirectoriesFacets::create($facet_item);
+      $facet->save();
+      $facet_entities[] = $facet;
+    }
+    $facet_labels = array_column($facets, 'title');
+
+    // Set up a directory channel and assign the facets to it.
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+
+    $channel_node = $this->createNode([
+      'title' => 'Directory channel',
+      'type' => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+      'body' => $body,
+      'localgov_directory_channel_types' => [
+        [
+          'target_id' => 'localgov_directories_page',
+        ],
+      ],
+      'localgov_directory_facets_enable' => [
+        [
+          'target_id' => $facet_types[0],
+        ],
+        [
+          'target_id' => $facet_types[1],
+        ],
+      ],
+    ]);
+
+    // Set up some directory entires.
+    $directory_nodes = [
+      // Entry 1 has facet 1 only.
+      [
+        'title' => 'Entry 1 ' . $this->randomMachineName(8),
+        'type' => 'localgov_directories_page',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_channels' => [
+          [
+            'target_id' => $channel_node->id(),
+          ],
+        ],
+        'localgov_directory_facets_select' => [
+          [
+            'target_id' => $facet_entities[0]->id(),
+          ],
+        ],
+      ],
+      [
+        // Entry 2 has facet 2 only.
+        'title' => 'Entry 2 ' . $this->randomMachineName(8),
+        'type' => 'localgov_directories_page',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_channels' => [
+          [
+            'target_id' => $channel_node->id(),
+          ],
+        ],
+        'localgov_directory_facets_select' => [
+          [
+            'target_id' => $facet_entities[1]->id(),
+          ],
+        ],
+      ],
+      // Entry 3 has facet 1 and 3.
+      [
+        'title' => 'Entry 3 ' . $this->randomMachineName(8),
+        'type' => 'localgov_directories_page',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_channels' => [
+          [
+            'target_id' => $channel_node->id(),
+          ],
+        ],
+        'localgov_directory_facets_select' => [
+          [
+            'target_id' => $facet_entities[0]->id(),
+          ],
+          [
+            'target_id' => $facet_entities[2]->id(),
+          ],
+        ],
+      ],
+      // Entry 4 has all facets.
+      [
+        'title' => 'Entry 4 ' . $this->randomMachineName(8),
+        'type' => 'localgov_directories_page',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_directory_channels' => [
+          [
+            'target_id' => $channel_node->id(),
+          ],
+        ],
+        'localgov_directory_facets_select' => [
+          [
+            'target_id' => $facet_entities[0]->id(),
+          ],
+          [
+            'target_id' => $facet_entities[1]->id(),
+          ],
+          [
+            'target_id' => $facet_entities[2]->id(),
+          ],
+          [
+            'target_id' => $facet_entities[3]->id(),
+          ],
+        ],
+      ],
+    ];
+
+    foreach ($directory_nodes as $node) {
+      $this->createNode($node);
+    }
+
+    // Get titles for comparison.
+    $node_titles = array_column($directory_nodes, 'title');
+
+    // Run cron so the directory entires are indexed.
+    $this->cronRun();
+
+    // Check facets and check the right entries are shown.
+    $directory_url = $channel_node->toUrl()->toString();
+    $this->drupalGet($directory_url);
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Initially all four should be avalible.
+    $this->assertSession()->pageTextContains($node_titles[0]);
+    $this->assertSession()->pageTextContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // Facet 1.
+    // Click facet 1, should show entry 1, 3 and 4.
+    $this->getSession()->getPage()->clickLink($facet_labels[0]);
+    $this->assertSession()->pageTextContains($node_titles[0]);
+    $this->assertSession()->pageTextNotContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // Facet 1 OR Facet 2.
+    // Click facet 2 (with 1 still clicked), should show entry 1, 2, 3 and 4.
+    $this->getSession()->getPage()->clickLink($facet_labels[1]);
+    $this->assertSession()->pageTextContains($node_titles[0]);
+    $this->assertSession()->pageTextContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // Facet 1 AND Facet 3.
+    // Click facet 2 to deselect, click facet 3 (with 1 still clicked),
+    // should show entry 3 and 4.
+    $this->getSession()->getPage()->clickLink($facet_labels[1]);
+    $this->getSession()->getPage()->clickLink($facet_labels[2]);
+    $this->assertSession()->pageTextNotContains($node_titles[0]);
+    $this->assertSession()->pageTextNotContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // Facet 1 AND (Facet 3 OR Facet 4).
+    // Click facet 4 (with 1 and 3 still clicked),
+    // should show entry 3 and 4.
+    $this->getSession()->getPage()->clickLink($facet_labels[3]);
+    $this->assertSession()->pageTextNotContains($node_titles[0]);
+    $this->assertSession()->pageTextNotContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // Facet 1 AND Facet 4.
+    // Click facet 3 to deselect (with 1 and 4 still clicked),
+    // should show entry 4 only.
+    $this->getSession()->getPage()->clickLink($facet_labels[2]);
+    $this->assertSession()->pageTextNotContains($node_titles[0]);
+    $this->assertSession()->pageTextNotContains($node_titles[1]);
+    $this->assertSession()->pageTextNotContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+
+    // (Facet 1 OR Facet 2) AND (Facet 3 OR Facet 4).
+    // Click facet 2 and 3 (with 1 and 4 still clicked),
+    // all facets selected, but should only show entry 3 and 4.
+    $this->getSession()->getPage()->clickLink($facet_labels[1]);
+    $this->getSession()->getPage()->clickLink($facet_labels[2]);
+    $this->assertSession()->pageTextNotContains($node_titles[0]);
+    $this->assertSession()->pageTextNotContains($node_titles[1]);
+    $this->assertSession()->pageTextContains($node_titles[2]);
+    $this->assertSession()->pageTextContains($node_titles[3]);
+  }
+
+}

--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -46,7 +46,16 @@ class FacetsTest extends BrowserTestBase {
    *
    * @var array
    */
-  protected $facetLabels;
+  protected $facetLabels = [];
+
+  /**
+   * Facet entities.
+   *
+   * Used to set facets accross each test.
+   *
+   * @var array
+   */
+  protected $facetEntities = [];
 
   /**
    * Channel node page.
@@ -109,9 +118,9 @@ class FacetsTest extends BrowserTestBase {
     foreach ($facets as $facet_item) {
       $facet = LocalgovDirectoriesFacets::create($facet_item);
       $facet->save();
-      $this->facet_entities[] = $facet;
+      $this->facetEntities[] = $facet;
     }
-    $this->facet_labels = array_column($facets, 'title');
+    $this->facetLabels = array_column($facets, 'title');
 
     // Set up a directory channel and assign the facets to it.
     $body = [
@@ -163,7 +172,7 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[0]->id(),
+            'target_id' => $this->facetEntities[0]->id(),
           ],
         ],
       ],
@@ -179,7 +188,7 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[1]->id(),
+            'target_id' => $this->facetEntities[1]->id(),
           ],
         ],
       ],
@@ -195,10 +204,10 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[0]->id(),
+            'target_id' => $this->facetEntities[0]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[2]->id(),
+            'target_id' => $this->facetEntities[2]->id(),
           ],
         ],
       ],
@@ -214,16 +223,16 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[0]->id(),
+            'target_id' => $this->facetEntities[0]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[1]->id(),
+            'target_id' => $this->facetEntities[1]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[2]->id(),
+            'target_id' => $this->facetEntities[2]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[3]->id(),
+            'target_id' => $this->facetEntities[3]->id(),
           ],
         ],
       ],
@@ -251,7 +260,7 @@ class FacetsTest extends BrowserTestBase {
 
     // Facet 1.
     // Click facet 1, should show entry 1, 3 and 4.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[0]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[0]);
     $this->assertSession()->pageTextContains($node_titles[0]);
     $this->assertSession()->pageTextNotContains($node_titles[1]);
     $this->assertSession()->pageTextContains($node_titles[2]);
@@ -259,7 +268,7 @@ class FacetsTest extends BrowserTestBase {
 
     // Facet 1 OR Facet 2.
     // Click facet 2 (with 1 still clicked), should show entry 1, 2, 3 and 4.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[1]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[1]);
     $this->assertSession()->pageTextContains($node_titles[0]);
     $this->assertSession()->pageTextContains($node_titles[1]);
     $this->assertSession()->pageTextContains($node_titles[2]);
@@ -268,8 +277,8 @@ class FacetsTest extends BrowserTestBase {
     // Facet 1 AND Facet 3.
     // Click facet 2 to deselect, click facet 3 (with 1 still clicked),
     // should show entry 3 and 4.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[1]);
-    $this->getSession()->getPage()->clickLink($this->facet_labels[2]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[1]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[2]);
     $this->assertSession()->pageTextNotContains($node_titles[0]);
     $this->assertSession()->pageTextNotContains($node_titles[1]);
     $this->assertSession()->pageTextContains($node_titles[2]);
@@ -278,7 +287,7 @@ class FacetsTest extends BrowserTestBase {
     // Facet 1 AND (Facet 3 OR Facet 4).
     // Click facet 4 (with 1 and 3 still clicked),
     // should show entry 3 and 4.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[3]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[3]);
     $this->assertSession()->pageTextNotContains($node_titles[0]);
     $this->assertSession()->pageTextNotContains($node_titles[1]);
     $this->assertSession()->pageTextContains($node_titles[2]);
@@ -287,7 +296,7 @@ class FacetsTest extends BrowserTestBase {
     // Facet 1 AND Facet 4.
     // Click facet 3 to deselect (with 1 and 4 still clicked),
     // should show entry 4 only.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[2]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[2]);
     $this->assertSession()->pageTextNotContains($node_titles[0]);
     $this->assertSession()->pageTextNotContains($node_titles[1]);
     $this->assertSession()->pageTextNotContains($node_titles[2]);
@@ -296,8 +305,8 @@ class FacetsTest extends BrowserTestBase {
     // (Facet 1 OR Facet 2) AND (Facet 3 OR Facet 4).
     // Click facet 2 and 3 (with 1 and 4 still clicked),
     // all facets selected, but should only show entry 3 and 4.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[1]);
-    $this->getSession()->getPage()->clickLink($this->facet_labels[2]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[1]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[2]);
     $this->assertSession()->pageTextNotContains($node_titles[0]);
     $this->assertSession()->pageTextNotContains($node_titles[1]);
     $this->assertSession()->pageTextContains($node_titles[2]);
@@ -332,10 +341,10 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[0]->id(),
+            'target_id' => $this->facetEntities[0]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[2]->id(),
+            'target_id' => $this->facetEntities[2]->id(),
           ],
         ],
       ],
@@ -354,10 +363,10 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[0]->id(),
+            'target_id' => $this->facetEntities[0]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[3]->id(),
+            'target_id' => $this->facetEntities[3]->id(),
           ],
         ],
       ],
@@ -376,7 +385,7 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[1]->id(),
+            'target_id' => $this->facetEntities[1]->id(),
           ],
         ],
       ],
@@ -395,10 +404,10 @@ class FacetsTest extends BrowserTestBase {
         ],
         'localgov_directory_facets_select' => [
           [
-            'target_id' => $this->facet_entities[1]->id(),
+            'target_id' => $this->facetEntities[1]->id(),
           ],
           [
-            'target_id' => $this->facet_entities[3]->id(),
+            'target_id' => $this->facetEntities[3]->id(),
           ],
         ],
       ],
@@ -423,16 +432,16 @@ class FacetsTest extends BrowserTestBase {
     // Show facets where entries would show for:-
     // - group 1 AND no restriction.
     // - group 2 AND facet 1.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[0]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[0]);
 
     // Assert that facets 1, 2, 3 and 4 are visible.
     // Because entry 2 has facet 2 which is in the same group as facet 1,
     // user could click on facet 2 as an OR condition even though entry 2
     // is not visible. Facet 4 will be visible as entry 2 has facet 1 and 4.
-    $this->assertSession()->pageTextContains($this->facet_labels[0]);
-    $this->assertSession()->pageTextContains($this->facet_labels[1]);
-    $this->assertSession()->pageTextContains($this->facet_labels[2]);
-    $this->assertSession()->pageTextContains($this->facet_labels[3]);
+    $this->assertSession()->pageTextContains($this->facetLabels[0]);
+    $this->assertSession()->pageTextContains($this->facetLabels[1]);
+    $this->assertSession()->pageTextContains($this->facetLabels[2]);
+    $this->assertSession()->pageTextContains($this->facetLabels[3]);
 
     // Click facet 3.
     // Applies condition entries have facet 1 AND facet 3.
@@ -442,69 +451,69 @@ class FacetsTest extends BrowserTestBase {
     // Show facets where entries would show for:-
     // - group 1 AND facet 3.
     // - group 2 AND facet 1.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[2]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[2]);
 
     // Assert that facets 1, 3 and 4 are visible (2 should be hidden).
     // Since the AND condition that is now applied from facet 3 will
     // eliminate entry 2, so appling it would have no effect. Facet 4 will still
     // be visible as Entry 2 has facet 1 and facet 4, so user could click on
     // on facet 4 and see entry 2.
-    $this->assertSession()->pageTextContains($this->facet_labels[0]);
-    $this->assertSession()->pageTextNotContains($this->facet_labels[1]);
-    $this->assertSession()->pageTextContains($this->facet_labels[2]);
-    $this->assertSession()->pageTextContains($this->facet_labels[3]);
+    $this->assertSession()->pageTextContains($this->facetLabels[0]);
+    $this->assertSession()->pageTextNotContains($this->facetLabels[1]);
+    $this->assertSession()->pageTextContains($this->facetLabels[2]);
+    $this->assertSession()->pageTextContains($this->facetLabels[3]);
 
     // Click facet 4.
     // Applies condition entries have facet 1 AND (facet 3 OR facet 4).
     // Show facets where entries would show for:-
     // - group 1 AND (facet 3 or facet 4).
     // - group 2 AND facet 1.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[3]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[3]);
 
     // Assert that facets 1, 2, 3 and 4 are visible.
     // Since entry 4 has facet 2 and facet 4, when the AND condition is applied
     // from the second facet group (facets 3 & 4) this will allow facet 2 to be
     // selected as it selected it would now produce a valid result.
-    $this->assertSession()->pageTextContains($this->facet_labels[0]);
-    $this->assertSession()->pageTextContains($this->facet_labels[1]);
-    $this->assertSession()->pageTextContains($this->facet_labels[2]);
-    $this->assertSession()->pageTextContains($this->facet_labels[3]);
+    $this->assertSession()->pageTextContains($this->facetLabels[0]);
+    $this->assertSession()->pageTextContains($this->facetLabels[1]);
+    $this->assertSession()->pageTextContains($this->facetLabels[2]);
+    $this->assertSession()->pageTextContains($this->facetLabels[3]);
 
     // Click to deselect facet 1 and 3 and then click to select facet 2.
     // Applies condition entries have facet 2 AND facet 4.
     // Show facets where entries would show for:-
     // - group 1 AND facet 4.
     // - group 2 AND facet 2.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[0]);
-    $this->getSession()->getPage()->clickLink($this->facet_labels[2]);
-    $this->getSession()->getPage()->clickLink($this->facet_labels[1]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[0]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[2]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[1]);
 
     // Assert that facets 1, 2 and 4 are visible (3 should be hidden).
     // Since the AND condition from the first facet group will only apply to
     // facet 4 and the AND condition from the second group will apply to facet 1
     // OR facet 2 (entry 4 has facets 2 & 4, not shown entry 2 has facet 1 & 3
     // so facet 1 is reachable and will genrate a valid result).
-    $this->assertSession()->pageTextContains($this->facet_labels[0]);
-    $this->assertSession()->pageTextContains($this->facet_labels[1]);
-    $this->assertSession()->pageTextNotContains($this->facet_labels[2]);
-    $this->assertSession()->pageTextContains($this->facet_labels[3]);
+    $this->assertSession()->pageTextContains($this->facetLabels[0]);
+    $this->assertSession()->pageTextContains($this->facetLabels[1]);
+    $this->assertSession()->pageTextNotContains($this->facetLabels[2]);
+    $this->assertSession()->pageTextContains($this->facetLabels[3]);
 
     // Click to deselect facet 4.
     // Applies conditions entries have facet 2.
     // Show facets where entries would show for:-
     // - group 1 AND no restriction.
     // - group 2 AND facet 2.
-    $this->getSession()->getPage()->clickLink($this->facet_labels[3]);
+    $this->getSession()->getPage()->clickLink($this->facetLabels[3]);
 
     // Assert that facet 1, 2 and 4 are visible (3 should be hidden).
     // Since no AND condition applies from the second facet group, facet 1
     // can be potentially selected in an OR group with facet 2 as the hidden
     // entry 1 has facet 1. The And condition from the first group with facet 2
     // prevents facet 3 from being reachable, as no entries have facet 2 and 3.
-    $this->assertSession()->pageTextContains($this->facet_labels[0]);
-    $this->assertSession()->pageTextContains($this->facet_labels[1]);
-    $this->assertSession()->pageTextNotContains($this->facet_labels[2]);
-    $this->assertSession()->pageTextContains($this->facet_labels[3]);
+    $this->assertSession()->pageTextContains($this->facetLabels[0]);
+    $this->assertSession()->pageTextContains($this->facetLabels[1]);
+    $this->assertSession()->pageTextNotContains($this->facetLabels[2]);
+    $this->assertSession()->pageTextContains($this->facetLabels[3]);
   }
 
 }


### PR DESCRIPTION
This is a rebase of #235 and #269 onto the 3.x branch

Fix #193

Adds a new facet plugin to directories  'LocalGov Directories - AND Facet Groups' which when added to the directories facets will perform facet searches using an OR filter within a facet group and an AND filter accross the groups.

This includes the work needed to try to find all possible facets in a group, this is needed as facets only presents facets that are in the result set, but an OR facet in each group needs to check if they would be visible when the other facets apply an AND filter onto them.

Based on work by @snpower, @ekes and @andybroomfield
 
- added 2 new facets plugins for processor and query_type. Together they provide a new pre_query processor on facets to AND facet groups together while still allowing OR within a facet group. This is based on initial code provided by Andy Broomfield
- fixed coding style issues
- coding style tweaks
- Enable And/Or custom facet behaviour by default on Directories Facet.
- Add a test for the facet And groups
- Remove unneeded assertStatusCode
- WIP Filter the facets so that the rest of the facets in group visible
- Add function to fetch sibling facets that would be avalible
- Coding standards.
- Accept no deep clone, clarify what the code is doing.
- Restore by reference for the conditions and fix for Drupal 10
- Adds test for checking that correct facets are visible during selection
- Coding standard fix on comments on the facet groups test
- Reverse the facet group filter removing the passed in facet filter group
