### PR TITLE
fix: added PHP 8.2 to workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - '~10.0'
         php-version:
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -110,6 +111,7 @@ jobs:
           - '~10.0'
         php-version:
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -145,6 +147,7 @@ jobs:
           - '~10.0'
         php-version:
           - '8.1'
+          - '8.2'
 
     steps:
 
@@ -179,6 +182,7 @@ jobs:
           - '~10.0'
         php-version:
           - '8.1'
+          - '8.2'
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "patches": {
             "drupal/facets": {
                 "Don't render facet block if backend isn't available: https://www.drupal.org/project/facets/issues/3311856": "https://git.drupalcode.org/issue/facets-3311856/-/commit/765d5ef4228906c7f201e116763f3018a7867c96.patch",
-                "PHP 8.2 compatibility for the 2.0.x branch: https://www.drupal.org/project/facets/issues/3336646": "https://git.drupalcode.org/project/facets/-/merge_requests/129.diff"
+                "PHP 8.2 compatibility for the 2.0.x branch: https://www.drupal.org/project/facets/issues/3336646": "https://www.drupal.org/files/issues/2023-08-16/3336646-function-is-deprecated.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "extra": {
         "patches": {
             "drupal/facets": {
-                "Don't render facet block if backend isn't available: https://www.drupal.org/project/facets/issues/3311856": "https://git.drupalcode.org/issue/facets-3311856/-/commit/765d5ef4228906c7f201e116763f3018a7867c96.patch"
+                "Don't render facet block if backend isn't available: https://www.drupal.org/project/facets/issues/3311856": "https://git.drupalcode.org/issue/facets-3311856/-/commit/765d5ef4228906c7f201e116763f3018a7867c96.patch",
+                "PHP 8.2 compatibility for the 2.0.x branch: https://www.drupal.org/project/facets/issues/3336646": "https://git.drupalcode.org/project/facets/-/merge_requests/129.diff"
             }
         }
     }


### PR DESCRIPTION
I noticed we are not currently checking PHP 8.2 for this module so I've added it to the workflow file.

Added PHP 8.2 compatibility patch for drupal/facets