### PR TITLE
Fix deprecated conditions in block config

### DIFF
--- a/config/optional/block.block.localgov_directories_facets_proximity_search.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search.yml
@@ -22,7 +22,7 @@ settings:
   block_id: localgov_directories_facets_proximity_search
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false

--- a/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
@@ -22,7 +22,7 @@ settings:
   block_id: localgov_directories_facets_proximity_search
 visibility:
   node_type:
-    id: node_type
+    id: entity_bundle:node
     bundles:
       localgov_directory: localgov_directory
     negate: false


### PR DESCRIPTION
The installation of `localgov_microsites` profile fails because of the deprecated (and removed) block visibility plugin. All other blocks in the module use `id: entity_bundle:node` already.