### PR TITLE
Also add facet configuration on updating the index (enabling) (#359)

### DIFF
--- a/config/optional/block.block.localgov_directories_facets.yml
+++ b/config/optional/block.block.localgov_directories_facets.yml
@@ -18,13 +18,14 @@ settings:
   id: 'facet_block:localgov_directories_facets'
   label: 'Directory facets'
   provider: facets
+  context_mapping: {  }
   label_display: '0'
   block_id: localgov_directories_facets
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/config/optional/block.block.localgov_directories_facets_proximity_search.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search.yml
@@ -18,13 +18,14 @@ settings:
   id: 'facet_block:localgov_directories_facets_proximity_search'
   label: 'Directory facets for proximity search'
   provider: facets
+  context_mapping: {  }
   label_display: '0'
   block_id: localgov_directories_facets_proximity_search
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_facets_proximity_search_scarfolk.yml
@@ -18,13 +18,14 @@ settings:
   id: 'facet_block:localgov_directories_facets_proximity_search'
   label: 'Directory facets for proximity search'
   provider: facets
+  context_mapping: {  }
   label_display: '0'
   block_id: localgov_directories_facets_proximity_search
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/config/optional/block.block.localgov_directories_facets_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_facets_scarfolk.yml
@@ -18,13 +18,14 @@ settings:
   id: 'facet_block:localgov_directories_facets'
   label: 'Directory facets'
   provider: facets
+  context_mapping: {  }
   label_display: '0'
   block_id: localgov_directories_facets
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Render\Element;
+use Drupal\facets\FacetInterface;
 use Drupal\field\FieldConfigInterface;
 use Drupal\localgov_directories\ConfigurationHelper;
 use Drupal\localgov_directories\Constants as Directory;
@@ -172,11 +173,35 @@ function localgov_directories_field_config_insert(FieldConfigInterface $field) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_insert().
+ *
+ * - Load optional configuration (presently facet blocks) when the facet is
+ *   configured.
+ */
+function localgov_directories_facets_facet_insert(FacetInterface $facet) {
+  \Drupal::service('config.installer')->installOptionalConfig(NULL, [
+    'config' => 'facets.facet.' . $facet->id(),
+  ]);
+}
+
+/**
  * Implements hook_ENTITY_TYPE_delete().
  */
 function localgov_directories_field_config_delete(FieldConfigInterface $field) {
   if ($field->getName() == Directory::CHANNEL_SELECTION_FIELD) {
     \Drupal::classResolver(ConfigurationHelper::class)->deletedDirectoryChannelField($field);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function localgov_directories_search_api_index_update(IndexInterface $index) {
+  if ($index->status()
+    && $index->getField(Directory::FACET_INDEXING_FIELD)
+  ) {
+    \Drupal::classResolver(ConfigurationHelper::class)
+      ->createFacet(Directory::FACET_CONFIG_ENTITY_ID, Directory::FACET_CONFIG_FILE);
   }
 }
 

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -352,8 +352,8 @@ class ConfigurationHelper implements ContainerInjectionInterface {
 
     try {
       $visibility = $block_config->getVisibility();
-      $visibility['node_type']['bundles'][$content_type] = $content_type;
-      $block_config->setVisibilityConfig('node_type', $visibility['node_type']);
+      $visibility['entity_bundle:node']['bundles'][$content_type] = $content_type;
+      $block_config->setVisibilityConfig('entity_bundle:node', $visibility['node_type']);
       $block_config->save();
     }
     catch (\Exception $e) {
@@ -400,11 +400,11 @@ class ConfigurationHelper implements ContainerInjectionInterface {
 
     try {
       $visibility = $block_config->getVisibility();
-      if (empty($visibility['node_type']['bundles'][$content_type])) {
+      if (empty($visibility['entity_bundle:node']['bundles'][$content_type])) {
         return FALSE;
       }
-      unset($visibility['node_type']['bundles'][$content_type]);
-      $block_config->setVisibilityConfig('node_type', $visibility['node_type']);
+      unset($visibility['entity_bundle:node']['bundles'][$content_type]);
+      $block_config->setVisibilityConfig('entity_bundle_node', $visibility['node_type']);
       $block_config->save();
     }
     catch (\Exception $e) {


### PR DESCRIPTION
* Facet block configurations. Update conditions, ensure installed.

 - Update the facet visibility,
 - Load the optional block config when facet config updated.

* Check facets configuration imported when index enabled.

The facets configuration won't be enabled when the index has the field added if the index is disabled at the time. Check when the index is updated, if it is enabled and has the field, create the facet (the create method also checks that it doesn't already exist).