### PR TITLE
Allow module reinstall

### DIFF
--- a/config/install/core.base_field_override.node.localgov_directory.promote.yml
+++ b/config/install/core.base_field_override.node.localgov_directory.promote.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - node.type.localgov_directory
 id: node.localgov_directory.promote

--- a/config/install/core.entity_form_display.node.localgov_directory.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_directory.default.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - field.field.node.localgov_directory.body
     - field.field.node.localgov_directory.localgov_directory_channel_types

--- a/config/install/core.entity_view_display.node.localgov_directory.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.default.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - field.field.node.localgov_directory.body
     - field.field.node.localgov_directory.localgov_directory_channel_types

--- a/config/install/core.entity_view_display.node.localgov_directory.search_index.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.search_index.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_directory.body

--- a/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.search_result.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_directory.body

--- a/config/install/core.entity_view_display.node.localgov_directory.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_directory.teaser.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directory.body

--- a/config/install/core.entity_view_mode.node.directory_index.yml
+++ b/config/install/core.entity_view_mode.node.directory_index.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: false
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.directory_index

--- a/config/install/field.field.node.localgov_directory.body.yml
+++ b/config/install/field.field.node.localgov_directory.body.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - field.storage.node.body
     - node.type.localgov_directory

--- a/config/install/field.field.node.localgov_directory.localgov_directory_channel_types.yml
+++ b/config/install/field.field.node.localgov_directory.localgov_directory_channel_types.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - field.storage.node.localgov_directory_channel_types
     - node.type.localgov_directory

--- a/config/install/field.storage.node.localgov_directory_address.yml
+++ b/config/install/field.storage.node.localgov_directory_address.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - address
     - node

--- a/config/install/field.storage.node.localgov_directory_channel_types.yml
+++ b/config/install/field.storage.node.localgov_directory_channel_types.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_channel_types

--- a/config/install/field.storage.node.localgov_directory_channels.yml
+++ b/config/install/field.storage.node.localgov_directory_channels.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_channels

--- a/config/install/field.storage.node.localgov_directory_email.yml
+++ b/config/install/field.storage.node.localgov_directory_email.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_email

--- a/config/install/field.storage.node.localgov_directory_files.yml
+++ b/config/install/field.storage.node.localgov_directory_files.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - media
     - node

--- a/config/install/field.storage.node.localgov_directory_job_title.yml
+++ b/config/install/field.storage.node.localgov_directory_job_title.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_job_title

--- a/config/install/field.storage.node.localgov_directory_name.yml
+++ b/config/install/field.storage.node.localgov_directory_name.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_name

--- a/config/install/field.storage.node.localgov_directory_notes.yml
+++ b/config/install/field.storage.node.localgov_directory_notes.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
     - text

--- a/config/install/field.storage.node.localgov_directory_phone.yml
+++ b/config/install/field.storage.node.localgov_directory_phone.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
     - telephone

--- a/config/install/field.storage.node.localgov_directory_title_sort.yml
+++ b/config/install/field.storage.node.localgov_directory_title_sort.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - node
 id: node.localgov_directory_title_sort

--- a/config/install/field.storage.node.localgov_directory_website.yml
+++ b/config/install/field.storage.node.localgov_directory_website.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   module:
     - link
     - node

--- a/config/install/node.type.localgov_directory.yml
+++ b/config/install/node.type.localgov_directory.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies: 
+  enforced:
+    module:
+      - localgov_directories
 name: 'Directory channel'
 type: localgov_directory
 description: 'Main directory landing page.'

--- a/config/install/search_api.index.localgov_directories_index_default.yml
+++ b/config/install/search_api.index.localgov_directories_index_default.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: false
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - field.storage.node.localgov_directory_channels
     - field.storage.node.localgov_directory_facets_select

--- a/config/install/views.view.localgov_directory_channel.yml
+++ b/config/install/views.view.localgov_directory_channel.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_directories
   config:
     - search_api.index.localgov_directories_index_default
   module:


### PR DESCRIPTION
Adding enforced dependencies to config files to allow reinstallation - see here: https://github.com/localgovdrupal/localgov_directories/issues/370