### PR TITLE
fix: drop drupal 10.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "drupal/core": "^10.2",
         "drupal/facets": "^2.0.7",
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.29",

--- a/localgov_directories.info.yml
+++ b/localgov_directories.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Directories'
 type: module
 description: 'Provides a directory facets entity.'
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 dependencies:
   - drupal:address
   - drupal:block

--- a/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
+++ b/tests/src/Functional/ChannelFacetsWidgetAdminTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\localgov_directories\Functional;
 
 use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\field_ui\Traits\FieldUiTestTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
@@ -19,10 +19,7 @@ class ChannelFacetsWidgetAdminTest extends BrowserTestBase {
   use FieldUiTestTrait;
   use ContentTypeCreationTrait;
   use NodeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * A user with minimum permissions for test.

--- a/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
+++ b/tests/src/FunctionalJavascript/EntityReferenceFacetsWidgetTest.php
@@ -8,7 +8,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
@@ -21,11 +21,7 @@ class EntityReferenceFacetsWidgetTest extends WebDriverTestBase {
 
   use ContentTypeCreationTrait;
   use NodeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
-
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * Array of directory nodes.

--- a/tests/src/Kernel/EntityReferenceChannelsSelectionTest.php
+++ b/tests/src/Kernel/EntityReferenceChannelsSelectionTest.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
@@ -17,10 +17,7 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class EntityReferenceChannelsSelectionTest extends KernelTestBase {
 
   use NodeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
+++ b/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\localgov_directories\Kernel;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
@@ -16,9 +16,6 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
 
   use NodeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
   use EntityReferenceTestTrait;
 
   /**

--- a/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
+++ b/tests/src/Kernel/EntityReferenceDirectoryEntryTypesTest.php
@@ -16,7 +16,7 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class EntityReferenceDirectoryEntryTypesTest extends KernelTestBase {
 
   use NodeCreationTrait;
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/FacetIndexFieldSetupTest.php
+++ b/tests/src/Kernel/FacetIndexFieldSetupTest.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\localgov_directories\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
 use Drupal\search_api\Entity\Index as SearchIndex;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
@@ -18,10 +18,7 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class FacetIndexFieldSetupTest extends KernelTestBase {
 
   use NodeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * Skip schema checks.

--- a/tests/src/Kernel/IndexTitleSortTest.php
+++ b/tests/src/Kernel/IndexTitleSortTest.php
@@ -11,7 +11,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Query\Query;
 use Drupal\search_api\Utility\Utility;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\search_api\Kernel\ResultsTrait;
 
@@ -24,10 +24,7 @@ class IndexTitleSortTest extends KernelTestBase {
 
   use NodeCreationTrait;
   use ResultsTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Drop Drupal 10.1 support, 10.1 was EoL June 2024

Change record: https://www.drupal.org/node/3401941