### PR TITLE
fix: use a tagged release for search_api_location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.3",
-        "drupal/search_api_location": "1.0-alpha4",
+        "drupal/search_api_location": "1.0.0-alpha4",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_geo": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.3",
-        "drupal/search_api_location": "1.x-dev#cf3e546770099b1f136c020ade79a650d4178ad6",
+        "drupal/search_api_location": "^1.0@alpha",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_geo": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.3",
-        "drupal/search_api_location": "^1.0@alpha",
+        "drupal/search_api_location": "1.0-alpha4",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_geo": "^2.0"
     },


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes https://github.com/localgovdrupal/localgov_directories/issues/381. We are pinning against a dev version of `search_api_location`, now there is a newer tagged release lets use that https://www.drupal.org/project/search_api_location