### PR TITLE
Feat: Support for the facets_form module

### DIFF
--- a/css/facets_form.css
+++ b/css/facets_form.css
@@ -1,0 +1,11 @@
+/**
+ * @file
+ * Style rules for facets widgets from the facets_form module.
+ */
+
+/**
+ * Hides the submit buttons on an empty facets form.
+ */
+.facet-empty ~ .form-actions {
+  display: none;
+}

--- a/localgov_directories.libraries.yml
+++ b/localgov_directories.libraries.yml
@@ -8,3 +8,10 @@ localgov_directories_search:
   dependencies:
     - core/drupalSettings
     - core/once
+
+# Hides submit buttons when there are no facet checkboxes to display.
+facets_form_checkboxes_empty:
+  version: 1.x
+  css:
+    state:
+      css/facets_form.css: {}

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\facets\FacetInterface;
 use Drupal\field\FieldConfigInterface;
@@ -52,6 +53,9 @@ function localgov_directories_theme() {
     'facets_item_list__dropdown__localgov_directories_facets_proximity_search' => [
       'base hook' => 'facets_item_list',
       'template'  => 'facets-item-list--dropdown--localgov-directories-facets',
+    ],
+    'checkboxes__localgov_directories_facets' => [
+      'base hook' => 'checkboxes',
     ],
   ];
 }
@@ -215,6 +219,51 @@ function localgov_directories_preprocess_facets_item_list(array &$variables) {
     \Drupal::service('class_resolver')
       ->getInstanceFromDefinition(DirectoryExtraFieldDisplay::class)
       ->preprocessFacetList($variables);
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for hook_theme_suggestions_checkbox_alter().
+ */
+function localgov_directories_theme_suggestions_checkboxes_alter(array &$suggestions, array $variables) {
+
+  $is_dir_facet_checkbox = isset($variables['element']['#name']) ? ($variables['element']['#name'] === Directory::FACET_CONFIG_ENTITY_ID || $variables['element']['#name'] === Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH) : FALSE;
+  if ($is_dir_facet_checkbox) {
+    $suggestions[] = 'checkboxes__localgov_directories_facets';
+  }
+}
+
+/**
+ * Preprocess for LocalGov Directory facet checkboxes.
+ *
+ * Groups facet checkboxes by their parent LocalGov Directory facet types.
+ */
+function template_preprocess_checkboxes__localgov_directories_facets(array &$variables) {
+
+  \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(DirectoryExtraFieldDisplay::class)
+    ->preprocessFacetCheckboxes($variables);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for hook_form_facets_form_alter().
+ *
+ * Hides form submit buttons for an empty LocalGov Directory facet form.
+ *
+ * @see Drupal\facets\FacetManager\DefaultFacetManager::build()
+ */
+function localgov_directories_form_facets_form_alter(array &$form, FormStateInterface $form_state) {
+
+  $has_empty_dir_facet = FALSE;
+  if (isset($form['facets'][Directory::FACET_CONFIG_ENTITY_ID][0]['#attributes']['class'][0])) {
+    $has_empty_dir_facet = $form['facets'][Directory::FACET_CONFIG_ENTITY_ID][0]['#attributes']['class'][0] === Directory::FACET_EMPTY_CLASS;
+  }
+  elseif (isset($form['facets'][Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH][0]['#attributes']['class'][0])) {
+    $has_empty_dir_facet = $form['facets'][Directory::FACET_CONFIG_ENTITY_ID_FOR_PROXIMITY_SEARCH][0]['#attributes']['class'][0] === Directory::FACET_EMPTY_CLASS;
+  }
+
+  if ($has_empty_dir_facet) {
+    $form['#attached']['library'][] = 'localgov_directories/facets_form_checkboxes_empty';
   }
 }
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -41,6 +41,8 @@ class Constants {
 
   const FACET_CONFIG_FILE_FOR_PROXIMITY_SEARCH = 'facets.facet.localgov_directories_facets_proximity_search';
 
+  const FACET_EMPTY_CLASS = 'facet-empty';
+
   const CHANNEL_VIEW = 'localgov_directory_channel';
 
   const CHANNEL_VIEW_DISPLAY = 'node_embed';

--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -330,7 +330,7 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
   public function preprocessFacetCheckboxes(array &$variables): void {
 
     $facet_id_list = Element::children($variables['element']);
-    $facet_options = array_filter($variables['element'], fn($facet_id) => in_array($facet_id, $facet_id_list), ARRAY_FILTER_USE_KEY);
+    $facet_options = array_filter($variables['element'], fn($facet_id) => in_array($facet_id, $facet_id_list, strict: TRUE), ARRAY_FILTER_USE_KEY);
     $variables['grouped_options'] = $this->groupDirFacetItems($facet_options);
   }
 

--- a/templates/checkboxes--localgov-directories-facets.html.twig
+++ b/templates/checkboxes--localgov-directories-facets.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * Default theme template for directory facet checkboxes.
+ *
+ * These checkboxes are used within the facets_form_checkbox facet widget.
+ *
+ * Available variables:
+ * - title: Optional list title.
+ * - grouped_options: checkboxes grouped by their corresponding LocalGov Directory facet type.  Each group array contains:
+ *   - title: Label of the facet type.
+ *   - items: Checkbox element.
+ *   - weight: Sorting weight of the facet type.
+ * - attributes: HTML attributes to be applied to the list.
+ *
+ * @see template_preprocess_checkboxes__localgov_directories_facets()
+ */
+#}
+<div class="facets-widget facets-widget--facets-form-checkbox">
+
+  {%- if title is not empty -%}
+    <h3>{{ title }}</h3>
+  {%- endif -%}
+
+  {% if grouped_options %}
+    <ul{{ attributes }}>
+    {%- for group_id, group_record in grouped_options -%}
+      <li>
+        <h4 class="facet-group__title">{{ group_record.title }}</h4>
+
+        <ul{{ attributes.addClass('facet-filter-checkboxes') }}>
+        {%- for checkbox in group_record.items -%}
+          <li>{{ checkbox }}</li>
+        {%- endfor -%}
+        </ul>
+      </li>
+    {%- endfor -%}
+    </ul>
+  {%- endif %}
+</div>


### PR DESCRIPTION
While rendering the `facets_form_checkbox` facet widget provided by the facets_form module, groups facet checkboxes according to their LocalGov Directory facet type.  This is similar to how the existing `checkbox` facet widget is rendered for LocalGov Directory facets.

Resolves #326

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds support for the [facets_form](https://drupal.org/project/facets_form) module.

## How to test

- Install the facets_form module.
- Edit the localgov_directories_facets facet from `/admin/config/search/facets/localgov_directories_facets/edit`
- Select the `Checkboxes (inside form)` widget near the top of the page and save settings.
- [Optional] Disable the existing facet block from the block layout page at `/admin/structure/block`.
- From the block layout page at `/admin/structure/block`, place the `Facet form: View Directory channel, display Embed` block in a sidebar.
-  Open an existing directory channel page and filter results using the facet checkboxes.

## How can we measure success?

Usual appearance and behaviour expected for LocalGov Directory facets.  Facets should work even without Javascript as we are no longer relying on Javascript to render the checkboxes.  The anchor tags with facet links are also not needed.  This stops crawlers from following these anchor tags.
