### PR TITLE
Allow upgrade to facets 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/core": "^10.2",
-        "drupal/facets": "^2.0.7",
+        "drupal/facets": "^2.0.7 || ^3.0",
         "drupal/pathauto": "^1.6",
         "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.3",


### PR DESCRIPTION
Allows facets to be upgraded to version 3.
This should keep the facet blocks in place from pre upgrade.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Allows the module upgrade.
That's all that's being enabled here. The extra work with allowing the facets filters module and Ajax support is best left to finders project.
<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Check that facets 3 can be installed

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Facets 3 is installable, whilst 2 is still supported.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Still need to throughly check directories works as is with facets 3.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a