### PR TITLE
fix/3.x 414 directory search default blocks

### DIFF
--- a/config/optional/block.block.localgov_directories_channel_search_block.yml
+++ b/config/optional/block.block.localgov_directories_channel_search_block.yml
@@ -20,10 +20,10 @@ settings:
   context_mapping:
     node: '@node.node_route_context:node'
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/config/optional/block.block.localgov_directories_channel_search_block_scarfolk.yml
+++ b/config/optional/block.block.localgov_directories_channel_search_block_scarfolk.yml
@@ -20,10 +20,10 @@ settings:
   context_mapping:
     node: '@node.node_route_context:node'
 visibility:
-  node_type:
-    id: entity_bundle:node
-    bundles:
-      localgov_directory: localgov_directory
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      localgov_directory: localgov_directory

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -353,7 +353,7 @@ class ConfigurationHelper implements ContainerInjectionInterface {
     try {
       $visibility = $block_config->getVisibility();
       $visibility['entity_bundle:node']['bundles'][$content_type] = $content_type;
-      $block_config->setVisibilityConfig('entity_bundle:node', $visibility['node_type']);
+      $block_config->setVisibilityConfig('entity_bundle:node', $visibility['entity_bundle:node']);
       $block_config->save();
     }
     catch (\Exception $e) {

--- a/src/ConfigurationHelper.php
+++ b/src/ConfigurationHelper.php
@@ -336,40 +336,46 @@ class ConfigurationHelper implements ContainerInjectionInterface {
    * The given block should appear in the sidebars of pages for the given
    * content type.
    *
-   * @param string $block_id
-   *   The block to update visibility for.
+   * @param string $plugin_id
+   *   The block plugin_id to update visibility for.
    * @param string $content_type
    *   The content type on which the block should be visible.
    *
    * @return bool
    *   True on success.
    */
-  public function blockAddContentType(string $block_id, string $content_type): bool {
-    $block_config = $this->entityTypeManager->getStorage('block')->load($block_id);
-    if (!$block_config instanceof BlockInterface) {
-      return FALSE;
-    }
+  public function blockAddContentType(string $plugin_id, string $content_type): bool {
+    $block_configs = $this->entityTypeManager->getStorage('block')->loadByProperties(['plugin' => $plugin_id]);
 
-    try {
-      $visibility = $block_config->getVisibility();
-      $visibility['entity_bundle:node']['bundles'][$content_type] = $content_type;
-      $block_config->setVisibilityConfig('entity_bundle:node', $visibility['entity_bundle:node']);
-      $block_config->save();
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Failed to add %content-type content type to %block-id block: %error-msg', [
+    foreach ($block_configs as $block_config) {
+      if (!$block_config instanceof BlockInterface) {
+        continue;
+      }
+
+      // Get the block id.
+      $block_id = $block_config->id();
+
+      try {
+        $visibility = $block_config->getVisibility();
+        $visibility['entity_bundle:node']['bundles'][$content_type] = $content_type;
+        $block_config->setVisibilityConfig('entity_bundle:node', $visibility['entity_bundle:node']);
+        $block_config->save();
+      }
+      catch (\Exception $e) {
+        $this->logger->error('Failed to add %content-type content type to %block-id block: %error-msg', [
+          '%content-type' => $content_type,
+          '%block-id' => $block_id,
+          '%error-msg' => $e->getMessage(),
+        ]);
+
+        return FALSE;
+      }
+
+      $this->logger->notice('Added %content-type content type to %block-id block.', [
         '%content-type' => $content_type,
         '%block-id' => $block_id,
-        '%error-msg' => $e->getMessage(),
       ]);
-
-      return FALSE;
     }
-
-    $this->logger->notice('Added %content-type content type to %block-id block.', [
-      '%content-type' => $content_type,
-      '%block-id' => $block_id,
-    ]);
 
     return TRUE;
   }

--- a/tests/src/Functional/SearchBlockTest.php
+++ b/tests/src/Functional/SearchBlockTest.php
@@ -55,7 +55,7 @@ class SearchBlockTest extends BrowserTestBase {
   }
 
   /**
-   *
+   * Test the search block is added to a new directory entry content type.
    */
   public function testSearchBlockAddedToEntryContentTypes() :void {
 
@@ -77,10 +77,9 @@ class SearchBlockTest extends BrowserTestBase {
       'localgov_directory_facets_enable' => [],
     ]);
     $dir_channel_node->save();
-    $dir_channel_page_path = $dir_channel_node->toUrl()->toString();
 
     $this->drupalPlaceBlock('localgov_directories_channel_search_block', [
-      'id' => 'localgov_directories_channel_search_block',
+      'id' => 'localgov_directories_channel_search_block_stark',
       'context_mapping' => ['node' => '@node.node_route_context:node'],
       'visibility' => [
         'entity_bundle:node' => [
@@ -106,6 +105,15 @@ class SearchBlockTest extends BrowserTestBase {
       'label' => 'Channels',
     ]);
     $field->save();
+
+    // Remove the search from manage display.
+    // @todo Check if this should be removed after adjusting the block.
+    $entity_view_display = $this->container->get('entity_type.manager')
+      ->getStorage('entity_view_display')
+      ->load('node.directory_entry.default');
+    if ($entity_view_display) {
+      $entity_view_display->removeComponent('localgov_directory_search')->save();
+    }
 
     // Allow directory entry to be inside directory channel.
     $dir_channel_node->localgov_directory_channel_types = [

--- a/tests/src/Functional/SearchBlockTest.php
+++ b/tests/src/Functional/SearchBlockTest.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\localgov_directories\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+use Drupal\Tests\field_ui\Traits\FieldUiTestTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 
 /**
  * Tests for the Directory search block.
@@ -13,6 +20,11 @@ use Drupal\Tests\BrowserTestBase;
  * - Prepopulated search field bug scenario.
  */
 class SearchBlockTest extends BrowserTestBase {
+
+  use FieldUiTestTrait;
+  use ContentTypeCreationTrait;
+  use NodeCreationTrait;
+  use EntityReferenceFieldCreationTrait;
 
   /**
    * Tests the search field.
@@ -43,6 +55,83 @@ class SearchBlockTest extends BrowserTestBase {
   }
 
   /**
+   *
+   */
+  public function testSearchBlockAddedToEntryContentTypes() :void {
+
+    $adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'access content',
+      'administer content types',
+      'administer node fields',
+      'administer node form display',
+      'administer node display',
+      'administer nodes',
+    ]);
+    $this->drupalLogin($adminUser);
+
+    $dir_channel_node = $this->createNode([
+      'title' => 'I am a directory channel page',
+      'type'  => 'localgov_directory',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_directory_facets_enable' => [],
+    ]);
+    $dir_channel_node->save();
+    $dir_channel_page_path = $dir_channel_node->toUrl()->toString();
+
+    $this->drupalPlaceBlock('localgov_directories_channel_search_block', [
+      'id' => 'localgov_directories_channel_search_block',
+      'context_mapping' => ['node' => '@node.node_route_context:node'],
+      'visibility' => [
+        'entity_bundle:node' => [
+          'id' => 'entity_bundle:node',
+          'negate' => FALSE,
+          'context_mapping' => [
+            'node' => '@node.node_route_context:node',
+          ],
+          'bundles' => [
+            'localgov_directory', 'localgov_directory',
+          ],
+        ],
+      ],
+    ]);
+
+    // Create a directory entry content type.
+    $this->createContentType(['type' => 'directory_entry']);
+
+    $field_storage = FieldStorageConfig::load('node.localgov_directory_channels');
+    $field = FieldConfig::create([
+      'field_storage' => $field_storage,
+      'bundle' => 'directory_entry',
+      'label' => 'Channels',
+    ]);
+    $field->save();
+
+    // Allow directory entry to be inside directory channel.
+    $dir_channel_node->localgov_directory_channel_types = [
+      'target_id' => 'directory_entry',
+    ];
+    $dir_channel_node->save();
+
+    // Create a directory entry.
+    $dir_entry_node = $this->createNode([
+      'title' => 'I am a directory entry page',
+      'type'  => 'directory_entry',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_directory_channels' => [
+        'target_id' => $dir_channel_node->id(),
+      ],
+    ]);
+    $dir_entry_node->save();
+
+    // Verify the search block is present on the entry.
+    $dir_entry_node_path = $dir_entry_node->toUrl()->toString();
+    $this->drupalGet($dir_entry_node_path);
+    $this->assertSession()->pageTextContains('Search I am a directory channel page');
+
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected $defaultTheme = 'stark';
@@ -51,6 +140,9 @@ class SearchBlockTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'localgov_directories',
+    'field_ui',
+    'block',
     'localgov_directories_db',
   ];
 


### PR DESCRIPTION
- **Also add facet configuration on updating the index (enabling) (#359) (#362)**
- **WIP: Position default blocks for new directory channels**
- **Switch to plugin_id for adding the search block**

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)