### PR TITLE
fix: return type hint spacing

### DIFF
--- a/tests/src/Functional/FacetsTest.php
+++ b/tests/src/Functional/FacetsTest.php
@@ -65,7 +65,7 @@ class FacetsTest extends BrowserTestBase {
   /**
    * Set up users, node and facets.
    */
-  protected function setUp() :void {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->drupalPlaceBlock('facet_block:localgov_directories_facets', []);

--- a/tests/src/Functional/SearchBlockTest.php
+++ b/tests/src/Functional/SearchBlockTest.php
@@ -20,7 +20,7 @@ class SearchBlockTest extends BrowserTestBase {
    * When a Directory channel page is loaded, the search field in the channel
    * search block should be empty.
    */
-  public function testIsSearchFieldEmpty() :void {
+  public function testIsSearchFieldEmpty(): void {
 
     $dir_channel_node = $this->createNode([
       'title' => 'I am a directory channel page',


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes spacing issues with the return type hint. Getting ahead of these now before the Drupal coding standards change is implemented to check for this.