### PR TITLE
WIP: Option to hide map per directory

### DIFF
--- a/config/install/field.field.node.localgov_directory.localgov_directory_hide_map.yml
+++ b/config/install/field.field.node.localgov_directory.localgov_directory_hide_map.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_map
+    - node.type.localgov_directory
+id: node.localgov_directory.field_hide_map
+field_name: field_hide_map
+entity_type: node
+bundle: localgov_directory
+label: 'Hide Map'
+description: 'Set to "Yes" if you wish to hide the map for this Directory Channel'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/install/field.storage.node.localgov_directory_hide_map.yml
+++ b/config/install/field.storage.node.localgov_directory_hide_map.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hide_map
+field_name: field_hide_map
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
+++ b/modules/localgov_directories_location/src/LocationExtraFieldDisplay.php
@@ -58,6 +58,11 @@ class LocationExtraFieldDisplay implements TrustedCallbackInterface {
    * Retrieves view, and sets render array.
    */
   protected function getViewEmbed(NodeInterface $node) {
+    $hide_map = $node->field_hide_map->value;
+    if ($hide_map) {
+      return;
+    }
+    
     $view = Views::getView('localgov_directory_channel');
     if (!$view || !$view->access('embed_map')) {
       return;


### PR DESCRIPTION
WORK IN PROGRESS

Works with config export, need to add logic to insert the field to existing installations.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)