### PR TITLE
Add config for simple sitemap

### DIFF
--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -27,6 +27,17 @@ function localgov_directories_install($is_syncing) {
   if ($services) {
     localgov_directories_optional_fields_settings($services);
   }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_directory', [
+      'index' => TRUE,
+      'priority' => '0.5',
+    ]);
+  }
 }
 
 /**

--- a/modules/localgov_directories_org/localgov_directories_org.install
+++ b/modules/localgov_directories_org/localgov_directories_org.install
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Update functions for the LocalGov Directories Promo Page.
+ */
+
+use Drupal\node\Entity\Node;
+use Drupal\pathauto\Entity\PathautoPattern;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_directories_org_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_directories_org', [
+      'index' => TRUE,
+      'priority' => '0.5',
+    ]);
+  }
+}

--- a/modules/localgov_directories_org/localgov_directories_org.install
+++ b/modules/localgov_directories_org/localgov_directories_org.install
@@ -2,11 +2,8 @@
 
 /**
  * @file
- * Update functions for the LocalGov Directories Promo Page.
+ * Update functions for the LocalGov Directories Organisation.
  */
-
-use Drupal\node\Entity\Node;
-use Drupal\pathauto\Entity\PathautoPattern;
 
 /**
  * Implements hook_install().

--- a/modules/localgov_directories_org/localgov_directories_org.install
+++ b/modules/localgov_directories_org/localgov_directories_org.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_install().
  */
-function localgov_directories_org_install($is_syncing) {
+function localgov_directories_org_install($is_syncing): void {
   if ($is_syncing) {
     return;
   }

--- a/modules/localgov_directories_page/localgov_directories_page.install
+++ b/modules/localgov_directories_page/localgov_directories_page.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_install().
  */
-function localgov_directories_page_install($is_syncing) {
+function localgov_directories_page_install($is_syncing): void {
   if ($is_syncing) {
     return;
   }

--- a/modules/localgov_directories_page/localgov_directories_page.install
+++ b/modules/localgov_directories_page/localgov_directories_page.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the LocalGov Directories Venue.
+ * Install, update and uninstall functions for the LocalGov Directories Page.
  */
 
 /**

--- a/modules/localgov_directories_page/localgov_directories_page.install
+++ b/modules/localgov_directories_page/localgov_directories_page.install
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the LocalGov Directories Venue.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function localgov_directories_page_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_directories_page', [
+      'index' => TRUE,
+      'priority' => '0.5',
+    ]);
+  }
+}

--- a/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
+++ b/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
@@ -9,6 +9,26 @@ use Drupal\node\Entity\Node;
 use Drupal\pathauto\Entity\PathautoPattern;
 
 /**
+ * Implements hook_install().
+ */
+function localgov_directories_promo_page_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_directory_promo_page', [
+      'index' => TRUE,
+      'priority' => '0.5',
+    ]);
+  }
+}
+
+/**
  * Adds pathauto pattern if there is not one yet.
  */
 function localgov_directories_promo_page_update_8001() {

--- a/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
+++ b/modules/localgov_directories_promo_page/localgov_directories_promo_page.install
@@ -11,7 +11,7 @@ use Drupal\pathauto\Entity\PathautoPattern;
 /**
  * Implements hook_install().
  */
-function localgov_directories_promo_page_install($is_syncing) {
+function localgov_directories_promo_page_install($is_syncing): void {
   if ($is_syncing) {
     return;
   }

--- a/modules/localgov_directories_venue/localgov_directories_venue.install
+++ b/modules/localgov_directories_venue/localgov_directories_venue.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_install().
  */
-function localgov_directories_venue_install($is_syncing) {
+function localgov_directories_venue_install($is_syncing): void {
   if ($is_syncing) {
     return;
   }

--- a/modules/localgov_directories_venue/localgov_directories_venue.install
+++ b/modules/localgov_directories_venue/localgov_directories_venue.install
@@ -6,6 +6,26 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function localgov_directories_venue_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_directories_venue', [
+      'index' => TRUE,
+      'priority' => '0.5',
+    ]);
+  }
+}
+
+/**
  * Use new 'Embed' View Mode for Geo if not already altered.
  */
 function localgov_directories_venue_update_8001() {


### PR DESCRIPTION
Closes #40 

## What does this change?
Adds default config for simple sitemap - same approach as LocalGov News.

## How to test

Install the directories modules, make sure directories content types have default sitemap settings.
