### PR TITLE
Better exposed filter support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "localgovdrupal/localgov_services": "^2.1",
         "localgovdrupal/localgov_openreferral": "^2.0",
         "localgovdrupal/localgov_paragraphs": "^2.3",
-        "drupal/facets_form": "^1.0"
+        "drupal/facets_form": "^1.0",
+        "drupal/better_exposed_filters: "^7.0"
     },
     "suggest": {
         "drupal/facets_form": "Displays facets as checkboxes within a form.",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "localgovdrupal/localgov_openreferral": "^2.0",
         "localgovdrupal/localgov_paragraphs": "^2.3",
         "drupal/facets_form": "^1.0",
-        "drupal/better_exposed_filters: "^7.0"
+        "drupal/better_exposed_filters": "^7.0"
     },
     "suggest": {
         "drupal/facets_form": "Displays facets as checkboxes within a form.",

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -58,6 +58,10 @@ function localgov_directories_theme() {
     'checkboxes__localgov_directories_facets' => [
       'base hook' => 'checkboxes',
     ],
+    'bef_checkboxes_directory_facets' => [
+      'render element' => 'element',
+      'base hook' => 'bef_checkboxes',
+    ],
   ];
 }
 
@@ -313,4 +317,26 @@ function localgov_directories_set_default_permissions(): void {
   // Default grant permissions to view directory facets.
   user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view directory facets']);
   user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view directory facets']);
+}
+
+/**
+ * Implements hook_template_preprocess_bef_checkboxes_directory_facets().
+ */
+function template_preprocess_bef_checkboxes_directory_facets(array &$variables): void {
+  $element = $variables['element'];
+  $facet_groups = $element['#localgov_directory_facet_groups'];
+  $facet_group_elements = [];
+
+  // Split up the facet checkboxes into groups based on the facet group.
+  foreach ($facet_groups as $key => $options) {
+    $facet_group_elements[$key] = [
+      '#type' => 'fieldset',
+      '#title' => $key,
+    ];
+    $options = array_keys($options);
+    $facet_group_elements[$key]['children'] = array_map(function ($item) use ($element) {
+      return $element[$item];
+    }, $options);
+  }
+  $variables['localgov_directory_facet_groups'] = $facet_group_elements;
 }

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -60,7 +60,7 @@ function localgov_directories_theme() {
     ],
     'bef_checkboxes_directory_facets' => [
       'render element' => 'element',
-      'base hook' => 'bef_checkboxes',
+      'base_hook' => 'bef_checkboxes',
     ],
   ];
 }
@@ -328,12 +328,13 @@ function template_preprocess_bef_checkboxes_directory_facets(array &$variables):
   $facet_group_elements = [];
 
   // Split up the facet checkboxes into groups based on the facet group.
-  foreach ($facet_groups as $key => $options) {
+  foreach ($facet_groups as $key => $values) {
     $facet_group_elements[$key] = [
       '#type' => 'fieldset',
-      '#title' => $key,
+      '#title' => $values['title'],
+      '#weight' => $values['weight'],
     ];
-    $options = array_keys($options);
+    $options = array_keys($values['items']);
     $facet_group_elements[$key]['children'] = array_map(function ($item) use ($element) {
       return $element[$item];
     }, $options);

--- a/src/DirectoryExtraFieldDisplay.php
+++ b/src/DirectoryExtraFieldDisplay.php
@@ -23,6 +23,7 @@ use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
 use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Adds views display for the directory channel.
@@ -74,6 +75,13 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
   protected $routeMatch;
 
   /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * DirectoryExtraFieldDisplay constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -88,14 +96,17 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
    *   Form Builder.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   Current route match.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, EntityFieldManagerInterface $entity_field_manager, BlockManagerInterface $plugin_manager_block, FormBuilderInterface $form_builder, RouteMatchInterface $route_match) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, EntityFieldManagerInterface $entity_field_manager, BlockManagerInterface $plugin_manager_block, FormBuilderInterface $form_builder, RouteMatchInterface $route_match, RequestStack $request_stack) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityRepository = $entity_repository;
     $this->entityFieldManager = $entity_field_manager;
     $this->pluginBlockManager = $plugin_manager_block;
     $this->formBuilder = $form_builder;
     $this->routeMatch = $route_match;
+    $this->requestStack = $request_stack;
   }
 
   /**
@@ -108,7 +119,8 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
       $container->get('entity_field.manager'),
       $container->get('plugin.manager.block'),
       $container->get('form_builder'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('request_stack'),
     );
   }
 
@@ -353,7 +365,26 @@ class DirectoryExtraFieldDisplay implements ContainerInjectionInterface, Trusted
     // This is usually on a channel node. If so remove facets not active on
     // channel.
     $active_facets = NULL;
-    if (($channel = $this->routeMatch->getParameter('node'))
+    $route_name = $this->routeMatch->getRouteName();
+    $channel = match($route_name) {
+
+      // Embdeded on a page.
+      'entity.node.canonical' => $this->routeMatch->getParameter('node'),
+
+      // Handle views ajax request.
+      'views.ajax' => call_user_func(function () {
+        $query_str = $this->requestStack->getCurrentRequest()->getQueryString();
+        parse_str($query_str, $query);
+        if ($query['view_name'] == 'localgov_directory_channel' && $nid = intval($query['view_args'])) {
+          return $this->entityTypeManager->getStorage('node')->load($nid);
+        }
+        return NULL;
+      }),
+
+      // No valid channel found.
+      default => NULL,
+    };
+    if (!is_null($channel)
       && $channel instanceof NodeInterface
       && $channel->bundle() == 'localgov_directory'
     ) {

--- a/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
+++ b/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
@@ -46,7 +46,7 @@ class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactory
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): DirectoryFacetsCheckboxes {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     return new static(
       $configuration,
       $plugin_id,

--- a/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
+++ b/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
@@ -4,10 +4,10 @@ namespace Drupal\localgov_directories\Plugin\better_exposed_filters\filter;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\better_exposed_filters\Plugin\better_exposed_filters\filter\RadioButtons;
-use Drupal\localgov_directories\Constants as Directory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
 
 /**
  * Localgov directories facets widget implementation.
@@ -20,18 +20,27 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactoryPluginInterface {
 
   /**
-   * Entity type manager service.
+   * Class resolver service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\Core\DependencyInjection\ClassResolverInterface
    */
-  protected $entityTypeManager;
+  protected $classResolver;
 
   /**
-   * {@inheritdoc}
+   * Constructs a DirectoryFacetsCheckboxes object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param Drupal\Core\DependencyInjection\ClassResolverInterface $class_resolver
+   *   Class resolver service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, string $plugin_id, $plugin_definition, ClassResolverInterface $class_resolver) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
+    $this->classResolver = $class_resolver;
   }
 
   /**
@@ -42,7 +51,7 @@ class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactory
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager'),
+      $container->get('class_resolver'),
     );
   }
 
@@ -59,21 +68,14 @@ class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactory
     parent::exposedFormAlter($form, $form_state);
 
     if (!empty($form[$field_id]['#options'])) {
-      $facet_storage = $this->entityTypeManager->getStorage(Directory::FACET_CONFIG_ENTITY_ID);
-      $grouped_options = [];
-      foreach ($form[$field_id]['#options'] as $key => $option) {
-        $facet = $facet_storage->load($key);
-        $facet_type = $facet->bundle();
-        $grouped_options[$facet_type][$key] = $option;
-      }
-      $facet_type_storage = $this->entityTypeManager->getStorage(Directory::FACET_TYPE_CONFIG_ENTITY_ID);
-      foreach ($grouped_options as $facet_type => $options) {
-        $facet_type_entity = $facet_type_storage->load($facet_type);
-        $facet_type_label = $facet_type_entity->label();
-        $grouped_options[$facet_type_label] = $options;
-        unset($grouped_options[$facet_type]);
-      }
-      $form[$field_id]['#localgov_directory_facet_groups'] = $grouped_options;
+
+      // Use the groupDirFacetItems from the DirectoryExtraFieldDisplay class.
+      // This is the same as the facets block, which will group and filter
+      // the avalible facets to the relevant directory channel.
+      $grouped_items = $this->classResolver
+        ->getInstanceFromDefinition(DirectoryExtraFieldDisplay::class)
+        ->groupDirFacetItems($form[$field_id]['#options']);
+      $form[$field_id]['#localgov_directory_facet_groups'] = $grouped_items;
       $form[$field_id]['#theme'] = 'bef_checkboxes_directory_facets';
     }
   }

--- a/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
+++ b/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
@@ -6,7 +6,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\better_exposed_filters\Plugin\better_exposed_filters\filter\RadioButtons;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
 
 /**

--- a/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
+++ b/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
@@ -27,32 +27,12 @@ class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactory
   protected $classResolver;
 
   /**
-   * Constructs a DirectoryFacetsCheckboxes object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param Drupal\Core\DependencyInjection\ClassResolverInterface $class_resolver
-   *   Class resolver service.
-   */
-  public function __construct(array $configuration, string $plugin_id, $plugin_definition, ClassResolverInterface $class_resolver) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->classResolver = $class_resolver;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('class_resolver'),
-    );
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->classResolver = $container->get('class_resolver');
+    return $instance;
   }
 
   /**

--- a/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
+++ b/src/Plugin/better_exposed_filters/filter/DirectoryFacetsCheckboxes.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\localgov_directories\Plugin\better_exposed_filters\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\better_exposed_filters\Plugin\better_exposed_filters\filter\RadioButtons;
+use Drupal\localgov_directories\Constants as Directory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Localgov directories facets widget implementation.
+ *
+ * @BetterExposedFiltersFilterWidget(
+ *   id = "localgov_directory_facets",
+ *   label = @Translation("Localgov directory facets"),
+ * )
+ */
+class DirectoryFacetsCheckboxes extends RadioButtons implements ContainerFactoryPluginInterface {
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): DirectoryFacetsCheckboxes {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exposedFormAlter(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\views\Plugin\views\filter\FilterPluginBase $filter */
+    $filter = $this->handler;
+    // Form element is designated by the element ID which is user-
+    // configurable.
+    $field_id = $filter->options['is_grouped'] ? $filter->options['group_info']['identifier'] : $filter->options['expose']['identifier'];
+
+    parent::exposedFormAlter($form, $form_state);
+
+    if (!empty($form[$field_id]['#options'])) {
+      $facet_storage = $this->entityTypeManager->getStorage(Directory::FACET_CONFIG_ENTITY_ID);
+      $grouped_options = [];
+      foreach ($form[$field_id]['#options'] as $key => $option) {
+        $facet = $facet_storage->load($key);
+        $facet_type = $facet->bundle();
+        $grouped_options[$facet_type][$key] = $option;
+      }
+      $facet_type_storage = $this->entityTypeManager->getStorage(Directory::FACET_TYPE_CONFIG_ENTITY_ID);
+      foreach ($grouped_options as $facet_type => $options) {
+        $facet_type_entity = $facet_type_storage->load($facet_type);
+        $facet_type_label = $facet_type_entity->label();
+        $grouped_options[$facet_type_label] = $options;
+        unset($grouped_options[$facet_type]);
+      }
+      $form[$field_id]['#localgov_directory_facet_groups'] = $grouped_options;
+      $form[$field_id]['#theme'] = 'bef_checkboxes_directory_facets';
+    }
+  }
+
+}

--- a/templates/bef-checkboxes-directory-facets.html.twig
+++ b/templates/bef-checkboxes-directory-facets.html.twig
@@ -1,0 +1,13 @@
+{% set classes = [
+  'form-checkboxes',
+  'bef-checkboxes',
+  'bef-checkboxes-directory-facets',
+  show_select_all_none ? 'bef-select-all-none',
+  show_select_all_none_nested ? 'bef-select-all-none-nested',
+  display_inline ? 'form--inline'
+] %}
+<div{{ wrapper_attributes.addClass(classes) }}>
+  {% for facet_group in localgov_directory_facet_groups %}
+    {{ facet_group }}
+  {% endfor %}
+</div>

--- a/tests/src/Unit/FacetPreprocessTest.php
+++ b/tests/src/Unit/FacetPreprocessTest.php
@@ -15,6 +15,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\localgov_directories\DirectoryExtraFieldDisplay;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacets;
 use Drupal\localgov_directories\Entity\LocalgovDirectoriesFacetsType;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Unit tests for the DirectoryExtraFieldDisplay class.
@@ -40,7 +41,7 @@ class FacetPreprocessTest extends UnitTestCase {
    */
   public function testFacetTypeSorting() {
 
-    $test_obj = new DirectoryExtraFieldDisplay($this->mockEntityTypeManager, $this->mockEntityRepository, $this->mockEntityFieldManager, $this->mockBlockPluginManager, $this->mockFormBuilder, $this->mockRouteMatch);
+    $test_obj = new DirectoryExtraFieldDisplay($this->mockEntityTypeManager, $this->mockEntityRepository, $this->mockEntityFieldManager, $this->mockBlockPluginManager, $this->mockFormBuilder, $this->mockRouteMatch, $this->mockRequestStack);
 
     $facet_tpl_variables = [
       'items' => [
@@ -139,6 +140,7 @@ class FacetPreprocessTest extends UnitTestCase {
     $this->mockBlockPluginManager = $this->createMock(BlockManagerInterface::class);
     $this->mockFormBuilder        = $this->createMock(FormBuilderInterface::class);
     $this->mockRouteMatch         = $this->createMock(RouteMatchInterface::class);
+    $this->mockRequestStack       = $this->createMock(RequestStack::class);
   }
 
   /**
@@ -182,5 +184,12 @@ class FacetPreprocessTest extends UnitTestCase {
    * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   protected $mockRouteMatch;
+
+  /**
+   * Mock Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $mockRequestStack;
 
 }


### PR DESCRIPTION
WIP for #439

Adds initial support for using directory facets with better exposed filters.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)