### PR TITLE
Move populating title sort field later in the index process.

### DIFF
--- a/config/install/search_api.index.localgov_directories_index_default.yml
+++ b/config/install/search_api.index.localgov_directories_index_default.yml
@@ -2,9 +2,6 @@ langcode: en
 status: false
 dependencies:
   config:
-    - field.storage.node.localgov_directory_channels
-    - field.storage.node.localgov_directory_facets_select
-    - field.storage.node.localgov_directory_title_sort
     - core.entity_view_mode.node.directory_index
   module:
     - node
@@ -20,7 +17,7 @@ field_settings:
     type: text
     configuration:
       roles:
-        anonymous: anonymous
+        - anonymous
       view_mode:
         'entity:node':
           localgov_directories_page: directory_index
@@ -29,8 +26,8 @@ field_settings:
     label: Title
     datasource_id: 'entity:node'
     property_path: title
-    boost: 5.0
     type: text
+    boost: 5.0
     dependencies:
       module:
         - node
@@ -61,7 +58,7 @@ processor_settings:
     highlight_partial: false
   html_filter:
     weights:
-      preprocess_index: -15
+      preprocess_index: -48
       preprocess_query: -15
     all_fields: false
     fields:
@@ -77,19 +74,20 @@ processor_settings:
       strong: 2
   ignorecase:
     weights:
-      preprocess_index: -20
+      preprocess_index: -50
       preprocess_query: -20
     all_fields: true
     fields:
-      - localgov_directory_channels
-      - localgov_directory_title_sort
       - rendered_item
       - title
   language_with_fallback: {  }
+  localgov_directories_sort_field:
+    weights:
+      preprocess_index: -49
   rendered_item: {  }
   stemmer:
     weights:
-      preprocess_index: 0
+      preprocess_index: -42
       preprocess_query: 0
     all_fields: true
     fields:
@@ -100,7 +98,7 @@ processor_settings:
       texan: texa
   stopwords:
     weights:
-      preprocess_index: -5
+      preprocess_index: -44
       preprocess_query: -2
     all_fields: true
     fields:
@@ -144,7 +142,7 @@ processor_settings:
       - with
   tokenizer:
     weights:
-      preprocess_index: -6
+      preprocess_index: -45
       preprocess_query: -6
     all_fields: true
     fields:
@@ -156,12 +154,10 @@ processor_settings:
     minimum_word_size: '3'
   transliteration:
     weights:
-      preprocess_index: -20
+      preprocess_index: -47
       preprocess_query: -20
     all_fields: true
     fields:
-      - localgov_directory_channels
-      - localgov_directory_title_sort
       - rendered_item
       - title
 tracker_settings:

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -288,24 +288,6 @@ function template_preprocess_localgov_directories_facets(array &$variables) {
 }
 
 /**
- * Implements hook_search_api_index_items_alter().
- *
- * Populate localgov_directory_title_sort if empty.
- */
-function localgov_directories_search_api_index_items_alter(IndexInterface $index, array &$items) {
-  foreach ($items as $item) {
-    if ($field = $item->getField('localgov_directory_title_sort')) {
-      $sort_value = $field->getValues();
-      if (empty($sort_value) || empty($sort_value[0])) {
-        // If the field is empty use the item title.
-        $sort_value = [trim($item->getOriginalObject()->getEntity()->label())];
-        $field->setValues($sort_value);
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_leaflet_map_view_style_alter().
  */
 function localgov_directories_leaflet_map_view_style_alter(&$js_settings, $leaflet_map) {

--- a/localgov_directories.post_update.php
+++ b/localgov_directories.post_update.php
@@ -2,7 +2,6 @@
 
 use Drupal\search_api\Entity\Index;
 
-
 /**
  * @file
  * Post update hooks for LocalGov Directories.
@@ -15,7 +14,7 @@ use Drupal\search_api\Entity\Index;
  * but we had installed condition plugins with this after it might have run.
  * No harm in running this multiple times.
  */
-function localgov_directories_post_update_replace_node_type_condition() {
+function localgov_directories_post_update_replace_node_type_condition(): void {
   $config_factory = \Drupal::configFactory();
   foreach ($config_factory->listAll('block.block.') as $block_config_name) {
     $block = $config_factory->getEditable($block_config_name);
@@ -36,7 +35,7 @@ function localgov_directories_post_update_replace_node_type_condition() {
  * Because we'd still been installing old config.
  * https://github.com/localgovdrupal/localgov_directories/pull/342/files.
  */
-function localgov_directories_post_update_replace_node_type_condition_again() {
+function localgov_directories_post_update_replace_node_type_condition_again(): void {
   $config_factory = \Drupal::configFactory();
   foreach ($config_factory->listAll('block.block.') as $block_config_name) {
     $block = $config_factory->getEditable($block_config_name);
@@ -58,7 +57,7 @@ function localgov_directories_post_update_replace_node_type_condition_again() {
  *
  * Existing functionality has moved into a processor that needs to enabled.
  */
-function localgov_directories_post_update_enable_sort_processor() {
+function localgov_directories_post_update_enable_sort_processor(): void {
   $index = Index::load('localgov_directories_index_default');
   $processors = $index->getProcessors();
   if (!isset($processors['localgov_directories_sort_field'])) {

--- a/localgov_directories.post_update.php
+++ b/localgov_directories.post_update.php
@@ -1,11 +1,11 @@
 <?php
 
-use Drupal\search_api\Entity\Index;
-
 /**
  * @file
  * Post update hooks for LocalGov Directories.
  */
+
+use Drupal\search_api\Entity\Index;
 
 /**
  * Updates the node type visibility condition.

--- a/localgov_directories.post_update.php
+++ b/localgov_directories.post_update.php
@@ -1,5 +1,8 @@
 <?php
 
+use Drupal\search_api\Entity\Index;
+
+
 /**
  * @file
  * Post update hooks for LocalGov Directories.
@@ -47,5 +50,28 @@ function localgov_directories_post_update_replace_node_type_condition_again() {
         $block->save(TRUE);
       }
     }
+  }
+}
+
+/**
+ * Enables the new Sort Field processor.
+ *
+ * Existing functionality has moved into a processor that needs to enabled.
+ */
+function localgov_directories_post_update_enable_sort_processor() {
+  $index = Index::load('localgov_directories_index_default');
+  $processors = $index->getProcessors();
+  if (!isset($processors['localgov_directories_sort_field'])) {
+    $weight = array_reduce(
+      $processors,
+      fn ($weight, $processor) => $processor->getWeight('preprocess_index') < $weight ? $processor->getWeight('preprocess_index') : $weight,
+      0
+    );
+    $processor = \Drupal::getContainer()
+      ->get('search_api.plugin_helper')
+      ->createProcessorPlugin($index, 'localgov_directories_sort_field');
+    $processor->setWeight('preprocess_index', $weight);
+    $index->addProcessor($processor);
+    $index->save();
   }
 }

--- a/modules/localgov_directories_db/config/conditional/search_api.index.localgov_directories_index_default.yml
+++ b/modules/localgov_directories_db/config/conditional/search_api.index.localgov_directories_index_default.yml
@@ -2,9 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.localgov_directory_channels
-    - field.storage.node.localgov_directory_facets_select
-    - field.storage.node.localgov_directory_title_sort
     - search_api.server.localgov_directories_default
     - core.entity_view_mode.node.directory_index
   module:
@@ -12,32 +9,16 @@ dependencies:
     - search_api
 id: localgov_directories_index_default
 name: Directories
-description: 'Default search index for LocalGov Directories channel, installed by LocalGov Directories Database.'
+description: 'Default search index for LocalGov Directories channel.'
 read_only: false
 field_settings:
-  localgov_directory_channels:
-    label: 'Directory channels'
-    datasource_id: 'entity:node'
-    property_path: localgov_directory_channels
-    type: integer
-    dependencies:
-      config:
-        - field.storage.node.localgov_directory_channels
-  localgov_directory_title_sort:
-    label: 'Title (sort)'
-    datasource_id: 'entity:node'
-    property_path: localgov_directory_title_sort
-    type: string
-    dependencies:
-      config:
-        - field.storage.node.localgov_directory_title_sort
   rendered_item:
     label: 'Rendered HTML output'
     property_path: rendered_item
     type: text
     configuration:
       roles:
-        anonymous: anonymous
+        - anonymous
       view_mode:
         'entity:node':
           localgov_directories_page: directory_index
@@ -46,8 +27,8 @@ field_settings:
     label: Title
     datasource_id: 'entity:node'
     property_path: title
-    boost: 5.0
     type: text
+    boost: 5.0
     dependencies:
       module:
         - node
@@ -55,8 +36,7 @@ datasource_settings:
   'entity:node':
     bundles:
       default: false
-      selected:
-        - localgov_directories_page
+      selected: {  }
     languages:
       default: true
       selected: {  }
@@ -79,7 +59,7 @@ processor_settings:
     highlight_partial: false
   html_filter:
     weights:
-      preprocess_index: -15
+      preprocess_index: -48
       preprocess_query: -15
     all_fields: false
     fields:
@@ -95,19 +75,20 @@ processor_settings:
       strong: 2
   ignorecase:
     weights:
-      preprocess_index: -20
+      preprocess_index: -50
       preprocess_query: -20
     all_fields: true
     fields:
-      - localgov_directory_channels
-      - localgov_directory_title_sort
       - rendered_item
       - title
   language_with_fallback: {  }
+  localgov_directories_sort_field:
+    weights:
+      preprocess_index: -49
   rendered_item: {  }
   stemmer:
     weights:
-      preprocess_index: 0
+      preprocess_index: -42
       preprocess_query: 0
     all_fields: true
     fields:
@@ -118,7 +99,7 @@ processor_settings:
       texan: texa
   stopwords:
     weights:
-      preprocess_index: -5
+      preprocess_index: -44
       preprocess_query: -2
     all_fields: true
     fields:
@@ -162,7 +143,7 @@ processor_settings:
       - with
   tokenizer:
     weights:
-      preprocess_index: -6
+      preprocess_index: -45
       preprocess_query: -6
     all_fields: true
     fields:
@@ -174,18 +155,17 @@ processor_settings:
     minimum_word_size: '3'
   transliteration:
     weights:
-      preprocess_index: -20
+      preprocess_index: -47
       preprocess_query: -20
     all_fields: true
     fields:
-      - localgov_directory_channels
-      - localgov_directory_title_sort
       - rendered_item
       - title
 tracker_settings:
   default:
     indexing_order: fifo
 options:
-  index_directly: true
   cron_limit: 50
+  index_directly: true
+  track_changes_in_references: true
 server: localgov_directories_default

--- a/src/Plugin/search_api/processor/TitleSortField.php
+++ b/src/Plugin/search_api/processor/TitleSortField.php
@@ -21,7 +21,7 @@ class TitleSortField extends ProcessorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function preprocessIndexItems(array $items) {
+  public function preprocessIndexItems(array $items): void {
     foreach ($items as $item) {
       if ($field = $item->getField('localgov_directory_title_sort')) {
         $sort_value = $field->getValues();

--- a/src/Plugin/search_api/processor/TitleSortField.php
+++ b/src/Plugin/search_api/processor/TitleSortField.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\localgov_directories\Plugin\search_api\processor;
+
+use Drupal\search_api\Processor\ProcessorPluginBase;
+
+/**
+ * Populates directories sort order field if empty.
+ *
+ * @SearchApiProcessor(
+ *   id = "localgov_directories_sort_field",
+ *   label = @Translation("LocalGov Directories sort field"),
+ *   description = @Translation("Populates default title value into optional sort field if it is empty."),
+ *   stages = {
+ *     "preprocess_index" = 0,
+ *   }
+ * )
+ */
+class TitleSortField extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocessIndexItems(array $items) {
+    foreach ($items as $item) {
+      if ($field = $item->getField('localgov_directory_title_sort')) {
+        $sort_value = $field->getValues();
+        if (empty($sort_value) || empty($sort_value[0])) {
+          // If the field is empty use the item title.
+          $sort_value = [trim($item->getOriginalObject()->getEntity()->label())];
+          $field->setValues($sort_value);
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_microsites/issues/524

## @todo

Needs update hook testing to enable the processor on existing indexes.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Moves populating the title sort field into a processor, rather than in item hook. The hook is called earlier and was causing some field item that caused issues with microsites indexing.

## How to test

There is an automated Kernel test for this field being populated. It still passes (locally).