### PR TITLE
fix/3.x 446 facets view update remove canioncal route

### DIFF
--- a/localgov_directories.install
+++ b/localgov_directories.install
@@ -38,6 +38,9 @@ function localgov_directories_install($is_syncing) {
       'priority' => '0.5',
     ]);
   }
+
+  // Allow anonymous and authenticated users to view directory facets.
+  localgov_directories_set_default_permissions();
 }
 
 /**
@@ -314,4 +317,15 @@ function localgov_directories_update_8008() {
   ) {
     \Drupal::keyValue('system.schema')->set('localgov_directories_db', 8000);
   }
+}
+
+/**
+ * Allow anonymous and authenticated users to view directory facets.
+ */
+function localgov_directories_update_8009(): void {
+  localgov_directories_set_default_permissions();
+
+  // Clear caches so removal of directory facets entity canonical route is
+  // picked up.
+  drupal_flush_all_caches();
 }

--- a/localgov_directories.links.task.yml
+++ b/localgov_directories.links.task.yml
@@ -1,15 +1,11 @@
-entity.localgov_directories_facets.view:
-  title: View
-  route_name: entity.localgov_directories_facets.canonical
-  base_route: entity.localgov_directories_facets.canonical
 entity.localgov_directories_facets.edit_form:
   title: Edit
   route_name: entity.localgov_directories_facets.edit_form
-  base_route: entity.localgov_directories_facets.canonical
+  base_route: entity.localgov_directories_facets.edit_form
 entity.localgov_directories_facets.delete_form:
   title: Delete
   route_name: entity.localgov_directories_facets.delete_form
-  base_route: entity.localgov_directories_facets.canonical
+  base_route: entity.localgov_directories_facets.edit_form
   weight: 10
 entity.localgov_directories_facets.collection:
   title: Directory Facets

--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -19,6 +19,7 @@ use Drupal\localgov_roles\RolesHelper;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\Entity\PathautoPattern;
 use Drupal\search_api\IndexInterface;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_theme().
@@ -320,4 +321,14 @@ function localgov_directories_leaflet_map_view_style_alter(&$js_settings, $leafl
  */
 function localgov_directories_facets_search_api_query_type_mapping_alter($backend_plugin_id, array &$query_types) {
   $query_types['localgov_directories'] = 'localgov_directories_query_type';
+}
+
+/**
+ * Set default permissions for anonymous and authenticated users.
+ */
+function localgov_directories_set_default_permissions(): void {
+
+  // Default grant permissions to view directory facets.
+  user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view directory facets']);
+  user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view directory facets']);
 }

--- a/src/Entity/LocalgovDirectoriesFacets.php
+++ b/src/Entity/LocalgovDirectoriesFacets.php
@@ -47,7 +47,6 @@ use Drupal\user\UserInterface;
  *   links = {
  *     "add-form" = "/admin/content/directories/facets/add/{localgov_directories_facets_type}",
  *     "add-page" = "/admin/content/directories/facets/add",
- *     "canonical" = "/admin/content/directories/facets/{localgov_directories_facets}",
  *     "edit-form" = "/admin/content/directories/facets/{localgov_directories_facets}/edit",
  *     "delete-form" = "/admin/content/directories/facets/{localgov_directories_facets}/delete",
  *     "collection" = "/admin/content/directories/facets"

--- a/src/Form/LocalgovDirectoriesFacetsForm.php
+++ b/src/Form/LocalgovDirectoriesFacetsForm.php
@@ -36,7 +36,9 @@ class LocalgovDirectoriesFacetsForm extends ContentEntityForm {
 
     $entity = $this->getEntity();
     $result = $entity->save();
-    $link = $entity->toLink($this->t('View'))->toRenderable();
+
+    // Since the canionical route has been removed, link to the edit form.
+    $link = $entity->toLink($this->t('Edit'), 'edit-form')->toRenderable();
 
     $message_arguments = ['%label' => $this->entity->label()];
     $logger_arguments = $message_arguments + ['link' => $this->renderer->render($link)];


### PR DESCRIPTION
Fix #446 

- Remove the canonical route for directory facets
- Allow anon and auth users to view directory facets

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Allow anonymous and authenticated users to view directory facets again, after the security update to facets 3.0.1 / 2.0.10

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

- Run the update and view a directory channel as an anonymous user.
- Try to edit and add directory facets and check functionality is still present.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Directory facets are viewable again.
<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Some sites might be using the directory facets canonical route.
<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

Before:
<img width="1226" height="734" alt="Screenshot 2025-09-01 at 12 12 01 pm" src="https://github.com/user-attachments/assets/94b2e8f2-64f8-4d68-b7d2-86acf53ab5d6" />

After:
<img width="1220" height="841" alt="Screenshot 2025-09-01 at 12 12 37 pm" src="https://github.com/user-attachments/assets/11eecf45-ac30-49b9-932b-43dd5d6cc191" />


<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a
