### PR TITLE
Fixes prefixes (subdirectory, language) being included in parent path pattern for other instances.

### DIFF
--- a/localgov_directories.module
+++ b/localgov_directories.module
@@ -125,8 +125,8 @@ function localgov_directories_pathauto_pattern_alter(PathautoPattern $pattern, a
   // it has opt-ed in with the field add the (optional) parent to the path.
   $entity = reset($context['data']);
   assert($entity instanceof ContentEntityInterface);
-  if ($entity->hasField('localgov_directory_channels') && strpos($pattern->getPattern(), '[node:localgov_directory_channels:0:entity:url:relative]') === FALSE) {
-    $pattern->setPattern('[node:localgov_directory_channels:0:entity:url:relative]/' . $pattern->getPattern());
+  if ($entity->hasField('localgov_directory_channels') && strpos($pattern->getPattern(), '[node:localgov_directory_channels:0:entity:url:path]') === FALSE) {
+    $pattern->setPattern('[node:localgov_directory_channels:0:entity:url:path]/' . $pattern->getPattern());
   }
 }
 


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_services/issues/335#issuecomment-3461396195 and https://github.com/localgovdrupal/localgov_services/issues/335